### PR TITLE
feat: 延遲標示 (relay)/(direct) + TODOS.md

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -20,6 +20,23 @@
 ### ~~NpcapSender 程式碼品質~~
 - **Completed:** v0.2.0 (2026-04-04) — npcap 已移除，改用 raw UDP + tunnel relay
 
+### Phase 2: Mid-game Hot Swap (DEFERRED)
+- 遊戲中從 relay 切換到 QUIC 直連，零資料遺失
+- **Blocked by:**
+  - Data loss during swap（drain 期間 War3 繼續送資料，try_send 丟棄）
+  - Asymmetric commit（一方 swap 另一方沒收到 commit）
+  - 需要 SwapPause + SwapAck 額外 protocol
+  - Premise 5 未驗證（proxy layer mid-game transport switch）
+- **Why deferred:** Phase 1 pre-game 路徑選擇已解決 90% 延遲問題，當前用戶量不支撐這個複雜度
+- **When:** 用戶量成長 + Phase 1 WAN 驗證完成後
+
+### P2P 延伸
+- [ ] UPnP 支援（~50 行，40% 額外直連率，零風險 quick win）
+- [ ] 多人 QUIC（>2 人目前用 WS relay）
+- [ ] QUIC stream 斷線後 WS 重建
+- [ ] Binary size CI gate（監控依賴膨脹）
+- [ ] 台灣 ISP hole punch 成功率實測（中華電信 vs 手機熱點）
+
 ### 多區域 Relay Server
 - 目前只有東京一個 VPS，台灣雙方延遲 ~60ms
 - 評估新加坡或香港 VPS 降低延遲

--- a/crates/client/src/app.rs
+++ b/crates/client/src/app.rs
@@ -8,7 +8,7 @@ use war3_protocol::messages::{ClientMessage, PlayerInfo, RoomInfo, ServerMessage
 
 use crate::net::discovery::NetEvent;
 use crate::net::packet::{RawUdpInjector, check_room};
-use crate::net::tunnel::{self, TunnelEvent};
+use crate::net::tunnel::{self, Transport, TunnelEvent};
 use crate::ui::lobby::{LobbyAction, LobbyPanel};
 use crate::ui::log_panel::LogPanel;
 use crate::ui::setup_wizard::SetupWizard;
@@ -80,6 +80,8 @@ pub struct War3App {
 
     /// P2P 直連：對方 IP（從 StunInfo 接收）
     peer_addr: Option<std::net::IpAddr>,
+    /// 目前遊戲傳輸路徑（relay 或 direct）
+    transport: Option<Transport>,
 }
 
 impl War3App {
@@ -124,6 +126,7 @@ impl War3App {
             injection_handle: None,
             latency_ms,
             peer_addr: None,
+            transport: None,
         };
 
         app.log_panel.info("War3 Battle Tool 啟動");
@@ -250,16 +253,25 @@ impl War3App {
                     self.log_panel.info("Tunnel proxy 就緒");
                     self.start_gameinfo_injection();
                 }
+                TunnelEvent::TransportSelected(t) => {
+                    self.transport = Some(t);
+                    match t {
+                        Transport::Direct => self.log_panel.info("傳輸: P2P 直連"),
+                        Transport::Relay => self.log_panel.info("傳輸: Relay 中繼"),
+                    }
+                }
                 TunnelEvent::Finished { error: None } => {
                     if let Some(h) = self.injection_handle.take() {
                         h.abort();
                     }
+                    self.transport = None;
                     self.log_panel.info("Tunnel 連線結束");
                 }
                 TunnelEvent::Finished { error: Some(e) } => {
                     if let Some(h) = self.injection_handle.take() {
                         h.abort();
                     }
+                    self.transport = None;
                     self.log_panel.error(format!("Tunnel 錯誤: {e}"));
                 }
                 TunnelEvent::GameinfoCaptured {
@@ -541,6 +553,7 @@ impl eframe::App for War3App {
                     is_hosting,
                     &self.cmd_tx,
                     latency,
+                    self.transport,
                 );
                 match action {
                     LobbyAction::None => {}

--- a/crates/client/src/net/tunnel.rs
+++ b/crates/client/src/net/tunnel.rs
@@ -17,11 +17,20 @@ const JOINER_BIND_IP: Ipv4Addr = Ipv4Addr::new(127, 0, 0, 2);
 /// Host War3 監聽的位址
 const HOST_WAR3_ADDR: SocketAddrV4 = SocketAddrV4::new(Ipv4Addr::LOCALHOST, WAR3_PORT);
 
+/// 傳輸路徑
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Transport {
+    Relay,
+    Direct,
+}
+
 /// Tunnel 連線結果
 #[derive(Debug)]
 pub enum TunnelEvent {
     /// TCP proxy ready，可以開始 inject GAMEINFO
     ProxyReady,
+    /// 傳輸路徑已確定
+    TransportSelected(Transport),
     /// Tunnel 已結束（正常或錯誤）
     Finished { error: Option<String> },
     /// GAMEINFO 擷取完成，可以送 CreateRoom
@@ -64,6 +73,7 @@ pub async fn run_joiner_tunnel(
         match quic::connect_direct(addr, &tunnel_token).await {
             Ok((quic_send, quic_recv)) => {
                 info!(%token_short, "QUIC 直連成功，等待 War3 TCP");
+                let _ = event_tx.send(TunnelEvent::TransportSelected(Transport::Direct));
                 let tcp_stream = match accept_war3_tcp(&tcp_listener, &token_short).await {
                     Some(s) => s,
                     None => {
@@ -86,7 +96,8 @@ pub async fn run_joiner_tunnel(
         }
     }
 
-    // 3. Fallback: WS relay
+    // Fallback: WS relay
+    let _ = event_tx.send(TunnelEvent::TransportSelected(Transport::Relay));
     let base_url = server_url.strip_suffix("/ws").unwrap_or(&server_url);
     let ws_url = format!("{base_url}/tunnel?token={tunnel_token}&role=join");
 
@@ -135,6 +146,7 @@ pub async fn run_host_tunnel(
         match quic::accept_direct(&tunnel_token).await {
             Ok((quic_send, quic_recv)) => {
                 info!(%token_short, "QUIC 直連成功，連接 War3 TCP");
+                let _ = event_tx.send(TunnelEvent::TransportSelected(Transport::Direct));
                 let tcp_stream = match connect_war3_tcp(&token_short).await {
                     Some(s) => s,
                     None => {
@@ -151,12 +163,13 @@ pub async fn run_host_tunnel(
                 return;
             }
             Err(e) => {
-                info!(%token_short, %e, "QUIC host 監聽失敗，fallback WS relay");
+                info!(%token_short, %e, "QUIC host 監聯失敗，fallback WS relay");
             }
         }
     } // peer_addr.is_some()
 
     // 2. Fallback: WS relay
+    let _ = event_tx.send(TunnelEvent::TransportSelected(Transport::Relay));
     let base_url = server_url.strip_suffix("/ws").unwrap_or(&server_url);
     let ws_url = format!("{base_url}/tunnel?token={tunnel_token}&role=host");
 

--- a/crates/client/src/ui/lobby.rs
+++ b/crates/client/src/ui/lobby.rs
@@ -1,7 +1,7 @@
 use eframe::egui;
-use war3_protocol::messages::{PlayerInfo, RoomInfo};
+use war3_protocol::messages::{ClientMessage, PlayerInfo, RoomInfo};
 
-use war3_protocol::messages::ClientMessage;
+use crate::net::tunnel::Transport;
 
 /// Action returned from `LobbyPanel::show` so the app can track pending state.
 pub enum LobbyAction {
@@ -45,6 +45,7 @@ impl LobbyPanel {
         is_hosting: bool,
         cmd_tx: &tokio::sync::mpsc::UnboundedSender<ClientMessage>,
         latency_ms: u64,
+        transport: Option<Transport>,
     ) -> LobbyAction {
         let mut action = LobbyAction::None;
 
@@ -53,6 +54,11 @@ impl LobbyPanel {
             ui.heading("房間列表");
             ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                 if latency_ms > 0 {
+                    let suffix = match transport {
+                        Some(Transport::Direct) => " (direct)",
+                        Some(Transport::Relay) => " (relay)",
+                        None => "",
+                    };
                     let color = if latency_ms < 30 {
                         egui::Color32::from_rgb(100, 200, 100) // 綠
                     } else if latency_ms < 80 {
@@ -60,7 +66,7 @@ impl LobbyPanel {
                     } else {
                         egui::Color32::from_rgb(255, 100, 100) // 紅
                     };
-                    ui.colored_label(color, format!("延遲: {latency_ms}ms"));
+                    ui.colored_label(color, format!("延遲: {latency_ms}ms{suffix}"));
                 }
             });
         });


### PR DESCRIPTION
## Summary
- 延遲顯示加上 "(relay)" / "(direct)" 後綴，玩家知道走哪條路
- `TunnelEvent::TransportSelected` 通知 UI 傳輸路徑
- TODOS.md 記錄 Phase 2 mid-game swap deferred 項目

## Test plan
- [x] `cargo check/test/clippy/fmt` 全過 (55 tests)
- [ ] 手動測試確認 UI 正確顯示後綴

🤖 Generated with [Claude Code](https://claude.com/claude-code)