### PR TITLE
feat: 防止空 GAMEINFO 建房 + tunnel 延遲監控

### DIFF
--- a/crates/client/src/app.rs
+++ b/crates/client/src/app.rs
@@ -79,6 +79,8 @@ pub struct War3App {
 
     /// Lobby RTT 測量（ms），由 discovery 更新
     latency_ms: Arc<AtomicU64>,
+    /// Tunnel RTT 測量（ms），遊戲中由 tunnel bridge 更新，0 表示無 tunnel
+    tunnel_latency_ms: Arc<AtomicU64>,
 
     /// P2P 直連：對方 IP（從 StunInfo 接收）
     peer_addr: Option<std::net::IpAddr>,
@@ -128,6 +130,7 @@ impl War3App {
             injection_handle: None,
             tunnel_handle: None,
             latency_ms,
+            tunnel_latency_ms: Arc::new(AtomicU64::new(0)),
             peer_addr: None,
             transport: None,
         };
@@ -174,9 +177,11 @@ impl War3App {
         let event_tx = self.tunnel_event_tx.clone();
         let peer_addr = self.peer_addr.take();
 
-        let latency = self.latency_ms.clone();
+        self.tunnel_latency_ms.store(0, Ordering::Relaxed);
+        let tunnel_lat = self.tunnel_latency_ms.clone();
         let handle = self.rt_handle.spawn(async move {
-            tunnel::run_joiner_tunnel(server_url, tunnel_token, peer_addr, event_tx, latency).await;
+            tunnel::run_joiner_tunnel(server_url, tunnel_token, peer_addr, event_tx, tunnel_lat)
+                .await;
         });
         self.tunnel_handle = Some(handle);
 
@@ -192,9 +197,11 @@ impl War3App {
         let event_tx = self.tunnel_event_tx.clone();
         let peer_addr = self.peer_addr.take();
 
-        let latency = self.latency_ms.clone();
+        self.tunnel_latency_ms.store(0, Ordering::Relaxed);
+        let tunnel_lat = self.tunnel_latency_ms.clone();
         let handle = self.rt_handle.spawn(async move {
-            tunnel::run_host_tunnel(server_url, tunnel_token, peer_addr, event_tx, latency).await;
+            tunnel::run_host_tunnel(server_url, tunnel_token, peer_addr, event_tx, tunnel_lat)
+                .await;
         });
         self.tunnel_handle = Some(handle);
     }
@@ -288,6 +295,7 @@ impl War3App {
                     }
                     self.tunnel_handle = None;
                     self.transport = None;
+                    self.tunnel_latency_ms.store(0, Ordering::Relaxed);
                     self.log_panel.info("Tunnel 連線結束");
                 }
                 TunnelEvent::Finished { error: Some(e) } => {
@@ -296,6 +304,7 @@ impl War3App {
                     }
                     self.tunnel_handle = None;
                     self.transport = None;
+                    self.tunnel_latency_ms.store(0, Ordering::Relaxed);
                     self.log_panel.error(format!("Tunnel 錯誤: {e}"));
                 }
                 TunnelEvent::GameinfoCaptured {
@@ -574,7 +583,13 @@ impl eframe::App for War3App {
                 } else {
                     None
                 };
-                let latency = self.latency_ms.load(Ordering::Relaxed);
+                // 遊戲中優先顯示 tunnel 延遲，否則顯示 lobby 延遲
+                let tunnel_lat = self.tunnel_latency_ms.load(Ordering::Relaxed);
+                let latency = if tunnel_lat > 0 {
+                    tunnel_lat
+                } else {
+                    self.latency_ms.load(Ordering::Relaxed)
+                };
                 let action = self.lobby.show(
                     ui,
                     &self.rooms,

--- a/crates/client/src/net/tunnel.rs
+++ b/crates/client/src/net/tunnel.rs
@@ -327,8 +327,11 @@ async fn bridge_tcp_ws_with_swap(
     let mut total_ws_to_tcp: u64 = 0;
     let mut buf = [0u8; RELAY_BUF_SIZE];
 
-    // WS Ping 延遲測量
-    let mut ping_timer = tokio::time::interval(TUNNEL_PING_INTERVAL);
+    // WS Ping 延遲測量（第一次延後，避免測到 connection setup）
+    let mut ping_timer = tokio::time::interval_at(
+        tokio::time::Instant::now() + TUNNEL_PING_INTERVAL,
+        TUNNEL_PING_INTERVAL,
+    );
     let mut ping_sent_at: Option<tokio::time::Instant> = None;
 
     // Phase 1: WS relay（可被 swap 中斷）
@@ -393,10 +396,12 @@ async fn bridge_tcp_ws_with_swap(
                 }
                 // channel closed → 背景 QUIC 失敗，繼續 WS relay
             }
-            // 定期 WS Ping 測量延遲
+            // 定期 WS Ping 測量延遲（前一個 Pong 還沒回來就跳過）
             _ = ping_timer.tick() => {
-                ping_sent_at = Some(tokio::time::Instant::now());
-                let _ = ws_sender.send(Message::Ping(Vec::new().into())).await;
+                if ping_sent_at.is_none() {
+                    ping_sent_at = Some(tokio::time::Instant::now());
+                    let _ = ws_sender.send(Message::Ping(Vec::new().into())).await;
+                }
             }
         }
     };


### PR DESCRIPTION
## Summary
- **防止空 GAMEINFO 建房**：War3 沒在 host 時按建立房間，顯示錯誤提示而非靜默失敗
- **Tunnel 延遲監控**：遊戲中每 5 秒 WS Ping/Pong 測量 RTT，即時更新 UI 延遲數字
- **獨立 tunnel/lobby 延遲**：`tunnel_latency_ms` 與 `latency_ms` 分離，遊戲中優先顯示 tunnel RTT

### Review fixes
- Ping timer 延後第一次 tick（避免測到 connection setup time）
- 不覆蓋未回 Pong 的 ping timestamp（避免 RTT 計算錯誤）

## Test Coverage
All 52 tests pass.

## Test plan
- [ ] War3 未開房時點建立房間 → 顯示「請先在 War3 中建立遊戲」
- [ ] War3 開房後建立房間 → 正常建立
- [ ] 遊戲中 UI 延遲數字每 5 秒更新，標示 (relay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)