### PR TITLE
feat: 品質追蹤系統整合 — Rust 適配搜查手冊 + 首輪搜查

### DIFF
--- a/.claude/skills/quality/SKILL.md
+++ b/.claude/skills/quality/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: quality
+description: Quality tracking system operations guide. Use when fixing bugs, managing defect/tech-debt/feature-gap/test-infra items, or running code quality audits.
+user-invocable: true
+---
+
+# 品質管理追蹤系統
+
+## 初始設定（首次使用時修改一次）
+
+將下方 `QUALITY_DIR` 改為你的品質系統**絕對路徑**：
+
+```
+QUALITY_DIR=/home/tim/side-projects/war3/quality
+```
+
+## 快速操作
+
+```bash
+# 列出所有活躍 Defect
+gh issue list --label "type:defect" --state open
+
+# 列出所有活躍 Tech Debt / Feature Gap / Test Infrastructure
+gh issue list --label "type:tech-debt" --state open
+gh issue list --label "type:feature-gap" --state open
+gh issue list --label "type:test-infra" --state open
+
+# 列出正在處理中的項目
+gh issue list --label "status:in-progress" --state open
+
+# 列出 Critical/High 項目
+gh issue list --label "priority:critical" --state open
+gh issue list --label "priority:high" --state open
+
+# 列出等待決策的項目
+gh issue list --label "status:blocked-by-decision" --state open
+```
+
+### 建立新項目
+
+依照 README.md「建立新項目」段落的完整步驟操作（路徑：`${QUALITY_DIR}/README.md`）。
+
+簡要流程：
+
+1. 判斷類型（見 `${QUALITY_DIR}/README.md` 的「如何判斷分類」決策樹）— Defect / Tech Debt / Feature Gap / Test Infrastructure
+2. 用對應的 Issue 模板建立 Issue：
+   - `gh issue create --template defect.yml`
+   - `gh issue create --template tech-debt.yml`
+   - `gh issue create --template feature-gap.yml`
+   - `gh issue create --template test-infra.yml`
+3. 加上 `priority:` label
+4. 若 Defect → 在 Issue body 填寫「缺陷子類別」連結搜查手冊
+
+### 修復完成後
+
+> **IMPORTANT:** 嚴格執行完成步驟（見 `${QUALITY_DIR}/README.md` 的「完成步驟」段落），缺任何一步 = 未完成。
+
+完成步驟適用於所有類型：
+1. 關閉 Issue + 填寫完成 comment（Commit/PR、修改摘要、測試結果）
+2. 若有相依 Issue → 檢查對方 Issue 是否需更新
+3. 若 Defect 且為系統性搜查中發現 → 確認搜查結果已記錄於 taxonomy
+
+---
+
+## 搜查手冊
+
+系統性搜查工具，定義已知缺陷類別。每個類別有：
+
+- **定義**：什麼模式構成此類缺陷
+- **搜查方式**：可執行的 grep/搜查指令
+- **搜查結果**：範圍與命中數、發現、low-risk observations、判定合理
+
+執行搜查時，讀取 `${QUALITY_DIR}/defect-taxonomy.md` 取得每個類別的具體搜查指令。
+
+搜查完成後，檢查該類別是否有 charter seed（「What grep can't find」段落）。如果有，向使用者建議 ET session — 見下方「探索式測試 (ET)」章節。
+
+---
+
+## 探索式測試 (ET)
+
+搜查手冊覆蓋已知的 grep 可搜模式。ET 處理 grep 搜不到的問題：業務邊界、意圖判斷、跨功能互動。
+
+完整方法論見 `${QUALITY_DIR}/discovery-strategy.md`。Charter 模板見 `${QUALITY_DIR}/et-charter-template.md`。
+
+### 何時建議 ET session
+
+| # | 觸發條件 | 信號 | 建議的 Charter |
+|---|----------|------|----------------|
+| 1 | **Post-sweep** | 剛完成某 D-XXX 類別的搜查 | 該類別的 charter seed |
+| 2 | **Design defect** | Issue 有 `root-cause:design` label | 探索同一設計決策影響的其他功能 |
+| 3 | **Production escape** | Issue 有 `escape:production` label | 探索自動化管道漏掉的同類場景 |
+| 4 | **New feature** | 使用者上線了新功能 | 探索邊界條件和錯誤處理路徑 |
+| 5 | **Pattern repeat** | 同區域短期內出現 2+ 個 Issue | 探索系統性根因 |
+
+### ET session 紀錄
+
+ET session 紀錄存為 markdown 檔案在 `${QUALITY_DIR}/et-sessions/` 目錄。不使用 GitHub Issues。
+
+---
+
+## 行為準則
+
+- **修復 bug 時**：檢查是否有對應的品質追蹤 Issue。若無且是系統性問題 → 建議建立（但由人類決定）。
+- **發現新問題時**：記錄到 README「待追蹤發現」段落。**不要主動升級為正式項目**。
+- **搜查手冊中發現同類問題時**：記錄到搜查手冊的「搜查結果」中。
+- **完成修復後**：嚴格執行「完成步驟」，不要遺漏任何一步。

--- a/.github/ISSUE_TEMPLATE/defect.yml
+++ b/.github/ISSUE_TEMPLATE/defect.yml
@@ -1,0 +1,118 @@
+name: "缺陷回報 (Defect)"
+description: "記錄非預期的錯誤 — 寫入時就是錯的"
+labels: ["type:defect"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > 定義與分類標準見 [quality/README.md](quality/README.md#分類體系)。
+        > 缺陷搜查手冊見 [quality/defect-taxonomy.md](quality/defect-taxonomy.md)。
+  - type: input
+    id: title
+    attributes:
+      label: "TL;DR"
+      description: "一句話摘要：問題是什麼、影響什麼"
+      placeholder: "catch 區塊吞沒 HTTP 錯誤，使用者看不到失敗通知"
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: "優先級"
+      description: "何時修？定義見 README"
+      options:
+        - "Critical — 立即處理（同日）"
+        - "High — 下個 Sprint（1-2 週）"
+        - "Medium — 規劃中（1 個月）"
+        - "Low — 有空時處理"
+    validations:
+      required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: "嚴重度"
+      description: "技術影響多大？"
+      options:
+        - "S1-Critical — 系統不可用或資料遺失"
+        - "S2-Major — 功能異常，無 workaround"
+        - "S3-Minor — 功能異常，有 workaround"
+        - "S4-Trivial — 外觀/文字問題"
+    validations:
+      required: true
+  - type: dropdown
+    id: cost
+    attributes:
+      label: "預估成本"
+      options:
+        - "S — < 2 小時"
+        - "M — 2 小時 ~ 1 天"
+        - "L — 1 ~ 3 天"
+        - "XL — > 3 天"
+  - type: dropdown
+    id: root-cause
+    attributes:
+      label: "根因類別"
+      options:
+        - "Design Defect — 架構/設計錯誤"
+        - "Implementation Error — 實作與設計不符"
+        - "Configuration Omission — 配置遺漏"
+        - "Framework Limitation — 框架限制未規避"
+        - "Missing Test Coverage — 缺少測試覆蓋"
+  - type: dropdown
+    id: escape-stage
+    attributes:
+      label: "逃逸階段"
+      description: "在哪個階段漏掉的？"
+      options:
+        - "Code Review"
+        - "Unit Test"
+        - "Integration Test"
+        - "E2E Test"
+        - "Production"
+  - type: dropdown
+    id: discovery-method
+    attributes:
+      label: "發現方式"
+      description: "如何發現此問題？使用品質系統的搜查或 ET 流程時填寫，否則留空。"
+      options:
+        - "taxonomy-sweep — 搜查手冊掃查"
+        - "et-session — 探索式測試"
+        - "code-review — Code review"
+        - "production — 生產環境"
+    validations:
+      required: false
+  - type: input
+    id: defect-category
+    attributes:
+      label: "缺陷子類別"
+      description: "對應 defect-taxonomy.md 的類別代碼"
+      placeholder: "D-SILENT / D-VALID / D-AUTH / D-TYPE / D-PERF / D-EDGE"
+  - type: textarea
+    id: current-state
+    attributes:
+      label: "現狀描述"
+      description: "詳細描述問題，含程式碼片段"
+    validations:
+      required: true
+  - type: textarea
+    id: affected-files
+    attributes:
+      label: "受影響檔案"
+      description: "列出相關檔案和具體問題"
+      placeholder: |
+        | 檔案 | 問題 |
+        | ---- | ---- |
+        | `src/api.ts` (L42) | catch 區塊只有 console.log |
+  - type: textarea
+    id: solution
+    attributes:
+      label: "解決方案"
+      description: "修復計畫（可分 Phase）"
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: "驗收標準"
+      description: "怎麼確認修好了？"
+      placeholder: |
+        - [ ] 錯誤正確傳遞給 UI
+        - [ ] 測試通過

--- a/.github/ISSUE_TEMPLATE/feature-gap.yml
+++ b/.github/ISSUE_TEMPLATE/feature-gap.yml
@@ -1,0 +1,61 @@
+name: "功能缺口 (Feature Gap)"
+description: "記錄功能不完整 — 缺少預期互動"
+labels: ["type:feature-gap"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > 定義與分類標準見 [quality/README.md](quality/README.md#分類體系)。
+  - type: input
+    id: title
+    attributes:
+      label: "TL;DR"
+      placeholder: "搜尋結果沒有分頁，超過 100 筆時無法瀏覽"
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: "優先級"
+      options:
+        - "Critical — 立即處理（同日）"
+        - "High — 下個 Sprint（1-2 週）"
+        - "Medium — 規劃中（1 個月）"
+        - "Low — 有空時處理"
+    validations:
+      required: true
+  - type: dropdown
+    id: cost
+    attributes:
+      label: "預估成本"
+      options:
+        - "S — < 2 小時"
+        - "M — 2 小時 ~ 1 天"
+        - "L — 1 ~ 3 天"
+        - "XL — > 3 天"
+  - type: input
+    id: user-impact
+    attributes:
+      label: "使用者影響"
+      description: "缺少此功能對使用者造成什麼問題？"
+      placeholder: "使用者無法找到歷史資料，需手動逐頁查看"
+    validations:
+      required: true
+  - type: textarea
+    id: current-state
+    attributes:
+      label: "現狀描述"
+    validations:
+      required: true
+  - type: textarea
+    id: affected-files
+    attributes:
+      label: "受影響檔案"
+  - type: textarea
+    id: solution
+    attributes:
+      label: "解決方案"
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: "驗收標準"

--- a/.github/ISSUE_TEMPLATE/tech-debt.yml
+++ b/.github/ISSUE_TEMPLATE/tech-debt.yml
@@ -1,0 +1,66 @@
+name: "技術債 (Tech Debt)"
+description: "記錄有意識的妥協 — 先上線再改"
+labels: ["type:tech-debt"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > 定義與分類標準見 [quality/README.md](quality/README.md#分類體系)。
+  - type: input
+    id: title
+    attributes:
+      label: "TL;DR"
+      placeholder: "為了趕上線，跳過了輸入驗證的完整性檢查"
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: "優先級"
+      options:
+        - "Critical — 立即處理（同日）"
+        - "High — 下個 Sprint（1-2 週）"
+        - "Medium — 規劃中（1 個月）"
+        - "Low — 有空時處理"
+    validations:
+      required: true
+  - type: dropdown
+    id: cost
+    attributes:
+      label: "預估成本"
+      options:
+        - "S — < 2 小時"
+        - "M — 2 小時 ~ 1 天"
+        - "L — 1 ~ 3 天"
+        - "XL — > 3 天"
+  - type: input
+    id: compromise-reason
+    attributes:
+      label: "妥協原因"
+      description: "為什麼做了這個妥協？"
+      placeholder: "deadline 壓力、等上游 API 穩定後再處理"
+    validations:
+      required: true
+  - type: input
+    id: planned-resolution
+    attributes:
+      label: "預計解決時機"
+      placeholder: "下個 Sprint / Phase 2 完成後 / 無時程"
+  - type: textarea
+    id: current-state
+    attributes:
+      label: "現狀描述"
+    validations:
+      required: true
+  - type: textarea
+    id: affected-files
+    attributes:
+      label: "受影響檔案"
+  - type: textarea
+    id: solution
+    attributes:
+      label: "解決方案"
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: "驗收標準"

--- a/.github/ISSUE_TEMPLATE/test-infra.yml
+++ b/.github/ISSUE_TEMPLATE/test-infra.yml
@@ -1,0 +1,66 @@
+name: "測試基礎設施 (Test Infrastructure)"
+description: "記錄測試覆蓋缺口與測試工具建設"
+labels: ["type:test-infra"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > 定義與分類標準見 [quality/README.md](quality/README.md#分類體系)。
+  - type: input
+    id: title
+    attributes:
+      label: "TL;DR"
+      placeholder: "API 端點缺少整合測試，只有手動驗證"
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: "優先級"
+      options:
+        - "Critical — 立即處理（同日）"
+        - "High — 下個 Sprint（1-2 週）"
+        - "Medium — 規劃中（1 個月）"
+        - "Low — 有空時處理"
+    validations:
+      required: true
+  - type: dropdown
+    id: cost
+    attributes:
+      label: "預估成本"
+      options:
+        - "S — < 2 小時"
+        - "M — 2 小時 ~ 1 天"
+        - "L — 1 ~ 3 天"
+        - "XL — > 3 天"
+  - type: input
+    id: coverage-gap
+    attributes:
+      label: "覆蓋缺口"
+      description: "缺少什麼測試覆蓋？"
+      placeholder: "POST /api/items 缺少邊界條件測試（空字串、超長輸入）"
+    validations:
+      required: true
+  - type: input
+    id: planned-resolution
+    attributes:
+      label: "預計解決時機"
+      placeholder: "下個 Sprint / Phase 2 完成後 / 無時程"
+  - type: textarea
+    id: current-state
+    attributes:
+      label: "現狀描述"
+    validations:
+      required: true
+  - type: textarea
+    id: affected-files
+    attributes:
+      label: "受影響檔案"
+  - type: textarea
+    id: solution
+    attributes:
+      label: "解決方案"
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: "驗收標準"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,13 @@ cargo build --release --package war3-client  # Windows only
 - master 有 branch protection（CI check 必須通過）
 - 開 feature branch → PR → CI 綠燈 → squash merge
 
+## 品質管理
+
+品質搜查手冊在 `quality/defect-taxonomy.md`。**操作前必須載入 `/quality` skill。**
+修復 bug 時，用 `gh issue list --label "type:defect"` 檢查是否有對應的品質追蹤 Issue。
+修復後嚴格執行 `/quality` skill 中的「完成步驟」。
+品質系統包含兩層發現機制：搜查手冊（grep 搜查已知模式）和探索式測試（ET session 探索 grep 盲區）。
+
 ## Skill routing
 
 When the user's request matches an available skill, ALWAYS invoke it using the Skill

--- a/quality/README.md
+++ b/quality/README.md
@@ -1,0 +1,144 @@
+<!-- Adapted from hottim900/quality-tracker -->
+
+# 品質管理追蹤
+
+war3-battle-tool 的品質管理體系。追蹤缺陷、技術債、功能缺口、測試覆蓋與工具建設，並維護品質防線。
+
+透過 GitHub Issues 管理品質項目（`#N` 格式引用），搭配 [defect-taxonomy.md](./defect-taxonomy.md) 搜查手冊進行系統性缺陷掃查。
+
+---
+
+## 快速查詢
+
+> 品質項目以 Issue 追蹤，透過 label 過濾取得即時結果。
+
+| 查詢                 | 指令                                                                         |
+| -------------------- | ---------------------------------------------------------------------------- |
+| 活躍項目             | `gh issue list --label "type:defect" --state open`                          |
+| Critical/High 活躍   | `gh issue list --label "priority:critical" --state open`                    |
+| In Progress 項目     | `gh issue list --label "status:in-progress" --state open`                   |
+| Blocked 項目         | `gh issue list --label "status:blocked-by-decision" --state open`           |
+| 搜查進度             | 見 [defect-taxonomy.md 分類總覽](./defect-taxonomy.md#分類總覽)              |
+
+---
+
+## 分類體系
+
+| 分類             | 定義                         | 處理策略                | Label              |
+| ---------------- | ---------------------------- | ----------------------- | ------------------ |
+| **Defect**       | 非預期的錯誤，寫入時就是錯的 | 立即修復 + 回溯流程漏洞 | `type:defect`      |
+| **Tech Debt**    | 有意識的妥協，先上線再改     | 排優先級，安排容量      | `type:tech-debt`   |
+| **Feature Gap**  | 功能不完整，缺少預期互動     | 放進 backlog            | `type:feature-gap` |
+| **Test Infrastructure** | 測試覆蓋缺口與測試工具建設 | 排優先級，系統性補齊 | `type:test-infra` |
+
+### 如何判斷分類？
+
+```
+這個問題是有意識的妥協嗎？
+├── 是 → 妥協的是測試覆蓋或測試工具嗎？
+│   ├── 是 → Test Infrastructure
+│   └── 否 → Tech Debt
+└── 否 → 程式碼行為與設計意圖一致嗎？
+    ├── 否 → Defect
+    └── 是 → 功能設計完整嗎？
+        ├── 否 → 缺少的是測試覆蓋嗎？
+        │   ├── 是 → Test Infrastructure
+        │   └── 否 → Feature Gap
+        └── 是 → 不需要追蹤
+```
+
+---
+
+## 定義參考
+
+### 優先級
+
+| 優先級       | 定義                       | 處理時機              |
+| ------------ | -------------------------- | --------------------- |
+| **Critical** | 影響生產穩定性或安全性     | 立即處理（同日）      |
+| **High**     | 阻礙開發效率或造成頻繁 bug | 下個 Sprint（1-2 週） |
+| **Medium**   | 增加維護成本但不影響功能   | 規劃中處理（1 個月）  |
+| **Low**      | 改善開發體驗，非必要       | 有空時處理（無 SLA）  |
+
+### 嚴重度（Defect 專用）
+
+| 嚴重度          | 定義                        |
+| --------------- | --------------------------- |
+| **S1-Critical** | 系統不可用或資料遺失        |
+| **S2-Major**    | 功能異常，無合理 workaround |
+| **S3-Minor**    | 功能異常，有 workaround     |
+| **S4-Trivial**  | 外觀/文字問題               |
+
+### 根因類別（Defect 專用）
+
+| 根因                       | 定義                         |
+| -------------------------- | ---------------------------- |
+| **Design Defect**          | 架構/設計層面的錯誤決策      |
+| **Implementation Error**   | 實作與設計意圖不符           |
+| **Configuration Omission** | 配置遺漏                     |
+| **Framework Limitation**   | 框架已知限制未規避           |
+| **Missing Test Coverage**  | 缺少測試導致未發現           |
+
+---
+
+## Label 參考
+
+| Prefix | 用途 | 必填？ | 值 |
+| ------ | ---- | ------ | -- |
+| `type:` | 項目類型 | **必填** | `defect` / `tech-debt` / `feature-gap` / `test-infra` |
+| `priority:` | 優先級 | **必填** | `critical` / `high` / `medium` / `low` |
+| `status:` | 細分狀態 | 選填 | `in-progress` / `blocked-by-decision` |
+| `severity:` | 嚴重度（Defect） | 選填 | `s1-critical` / `s2-major` / `s3-minor` / `s4-trivial` |
+| `cost:` | 成本 | 選填 | `s` / `m` / `l` / `xl` |
+| `escape:` | 逃逸階段（Defect） | 選填 | `code-review` / `unit-test` / `integration-test` / `e2e-test` / `production` |
+| `root-cause:` | 根因（Defect） | 選填 | `design` / `implementation` / `configuration` / `framework` / `test-coverage` |
+| `discovery-method:` | 發現方式 | 選填 | `taxonomy-sweep` / `et-session` / `code-review` / `production` |
+
+---
+
+## 待追蹤發現
+
+搜查中發現但尚未建立正式項目的問題。
+
+> **AI 行動指引：** 此段落僅供參考。**不要主動升級為正式項目** — 由人類決定何時建立。
+
+（尚無待追蹤項目）
+
+---
+
+## 建立新項目
+
+1. 用[分類決策樹](#如何判斷分類)判斷類型
+2. 用對應的 Issue 模板建立 Issue：
+   - `gh issue create --template defect.yml`
+   - `gh issue create --template tech-debt.yml`
+   - `gh issue create --template feature-gap.yml`
+   - `gh issue create --template test-infra.yml`
+3. 填寫模板中的所有欄位，加上 `priority:` label
+4. 若 Defect → 在 Issue body 填寫「缺陷子類別」連結搜查手冊
+5. 開始處理時，加上 `status:in-progress` label
+
+---
+
+## 完成步驟
+
+> **IMPORTANT:** 修復完成後，依序執行以下步驟。缺任何一步 = 未完成。
+
+1. 關閉 Issue，填寫完成 comment：
+   ```
+   ## 完成紀錄
+   **Commit/PR：** abc1234 或 PR 連結
+   **修改摘要：** 簡述實際修改
+   **測試結果：** X passed, 0 failed
+   ```
+2. 若有相依 Issue → 檢查對方 Issue 是否需更新
+3. 若為 Defect 且在系統性搜查中發現 → 確認搜查結果已記錄於 [defect-taxonomy.md](./defect-taxonomy.md)
+
+---
+
+## See also
+
+- [discovery-strategy.md](./discovery-strategy.md) — 雙層品質發現模型
+- [et-charter-template.md](./et-charter-template.md) — 探索式測試 Charter 模板
+- [defect-taxonomy.md](./defect-taxonomy.md) — 缺陷分類學搜查手冊
+- [quality-system-design-notes.md](./quality-system-design-notes.md) — 設計筆記與方法論來源

--- a/quality/defect-taxonomy.md
+++ b/quality/defect-taxonomy.md
@@ -1,0 +1,439 @@
+# 缺陷分類學 — 系統性搜查手冊（Rust 適配版）
+
+> **用途：** 定義已知和潛在的缺陷類別，提供可重複執行的搜查模式，讓開發者能快速找出同類問題。
+> 每個類別附帶定義、搜查方式、和搜查結果記錄。
+
+**建立日期：** 2026-04-07
+**最後更新：** 2026-04-07
+
+> 優先級、嚴重度、成本定義見 [README.md](./README.md#定義參考)
+
+### 搜查結果記錄格式
+
+每個類別搜查完畢後，記錄以下內容：
+
+1. **搜查範圍與命中數** — 例如「`crates/server/` + `crates/client/` + `crates/protocol/` 全部 `.rs`，共 N 個命中」。這是下次搜查的**基線**。
+2. **發現（建 Issue）** — 確認的缺陷，已建立追蹤 Issue。格式：`#N — 描述`
+3. **Low-risk observations（不建 Issue）** — 可疑但影響太低，不值得正式追蹤。記錄檔案位置和原因。
+4. **審查但判定合理（非缺陷）** — 經審查排除的項目。記錄判定理由，避免下次重複審查。
+
+### 分類策略
+
+每個類別的 grep 命中數會有差異。使用以下分類原則：
+
+- **D-SILENT 分類：** 建 Issue 如果 unwrap/ok/let_ 在網路 I/O 路徑或訊息處理器中。啟動初始化或 CLI 解析中的屬於 low-risk。
+- **D-AUTH 分類：** 建 Issue 如果端點缺少 rate limiting 或輸入驗證。內部使用或已有緩解措施的屬於 low-risk。
+- **D-PERF 分類：** clone() 和 allocation patterns 命中數會很高。只建 Issue 給 hot path 中的問題（async loop、每幀執行的 UI code）。一次性初始化的 clone/allocation 記錄為「判定合理」。
+- **D-RACE 分類：** spawn() 命中：只建 Issue 給 JoinHandle 被丟棄且沒有 abort() 或 select! 的情況。`tokio::select!` 搭配 JoinHandle arm 是結構化併發（安全），不需要追蹤。Arc<> 命中：只建 Issue 給 Arc 在 async await 點跨越迴圈的情況。
+
+**搜查上限：** 每次搜查最多建立 5 個 Issues。超出的發現記錄在對應類別的「## Pending Triage」段落。
+
+> **Claude Code 提示：** 以下各類別的 grep 指令為搜查邏輯的參考寫法。在 Claude Code 中請用內建 Grep 工具執行，`--include` 對應 `glob` 參數。
+
+---
+
+## 分類總覽
+
+| 代號     | 缺陷類別             | 層級          | 搜查狀態 |
+| -------- | -------------------- | ------------- | -------- |
+| D-SILENT | 靜默失敗與錯誤吞沒   | 全層          | 待搜查   |
+| D-VALID  | 輸入驗證缺口         | Protocol/API  | 待搜查   |
+| D-AUTH   | 認證、授權與安全防線 | Server        | 待搜查   |
+| D-TYPE   | 型別安全漏洞         | 全層          | 待搜查   |
+| D-PERF   | 效能問題             | 全層          | 待搜查   |
+| D-EDGE   | 邊界條件與資源限制   | 全層          | 待搜查   |
+| D-RACE   | 競態條件與並發問題   | Server/Client | 待搜查   |
+
+---
+
+## D-SILENT: 靜默失敗與錯誤吞沒
+
+### 定義
+
+unwrap()/expect() 導致 panic、.ok() 靜默丟棄 Result 的 Err、let _ = 靜默丟棄 Result/Option、未完成的 code paths。在面向玩家的工具中，panic = 閃退，靜默失敗 = 玩家看不到錯誤訊息。
+
+### 搜查方式
+
+```bash
+# unwrap() / expect() — panic 源頭
+grep -rn "\.unwrap()" . --include="*.rs" --exclude-dir=target --exclude-dir=tests | grep -v "#\[cfg(test" | grep -v "#\[test"
+grep -rn "\.expect(" . --include="*.rs" --exclude-dir=target --exclude-dir=tests | grep -v "#\[cfg(test" | grep -v "#\[test"
+
+# .ok() 靜默丟棄 Result 的 Err
+grep -rn "\.ok()" . --include="*.rs" --exclude-dir=target
+
+# let _ = expr; 靜默丟棄 Result/Option
+grep -rn "let _ =" . --include="*.rs" --exclude-dir=target
+
+# todo!() / unimplemented!() — 未完成的 code paths
+grep -rn "todo!()\|unimplemented!()" . --include="*.rs" --exclude-dir=target
+
+# match 中的 _ => {} 空 catch-all
+grep -rn "_ => {}" . --include="*.rs" --exclude-dir=target
+```
+
+> **搜查策略：** 優先檢查 unwrap()/expect()，因為這是最直接的 panic 源頭。.ok() 和 let _ = 次之。
+
+**搜查狀態：** 已搜查（2026-04-07）
+
+### What grep can't find (Charter seed)
+
+D-SILENT 的 grep pattern 能偵測 unwrap、.ok()、let _ =。它們**搜不到**：
+
+- **錯誤處理的語意正確性：** ? 運算子有用，但回傳的錯誤是否包含足夠上下文？例如：連線失敗只回傳 "connection error" 而非包含 IP 和 port
+- **try_send 的失敗影響：** mpsc channel 的 try_send 回傳 Err 時，被丟棄的訊息是否影響使用者？
+- **async 中的隱含 panic：** tokio::spawn 內部的 panic 不會傳播到外層，只會 abort 該 task
+
+Suggested Charter:
+```
+Target: 錯誤傳遞鏈 — 從 service 層到使用者面前
+Task: 故意觸發各種網路失敗（斷線、timeout、server 重啟），
+  追蹤錯誤訊息從產生到 UI 顯示的完整路徑，
+  檢查使用者是否得到足夠資訊
+Timebox: 30 min
+Trigger: D-SILENT 搜查完成
+```
+
+### 搜查結果
+
+**搜查範圍：** `crates/server/` + `crates/client/` + `crates/protocol/`（排除 tests/ 和 spike crates），共 ~80 個 unwrap/expect + ~30 個 let _ = 命中
+
+**發現：**
+
+- #23 — `app.rs:197,338,409` 的 `let _ = cmd_tx.send(...)` 靜默丟棄使用者命令（Register/CreateRoom）
+
+**Low-risk observations：**
+
+- `client/src/net/tunnel.rs` 多處 `let _ = event_tx.send(TunnelEvent::...)` — fire-and-forget 事件通知模式，channel 關閉時丟棄是預期行為
+- `client/src/net/quic.rs:116` — `Arc::get_mut().unwrap()` — 在 config 建構時呼叫，此時 Arc 只有唯一 owner
+
+**審查但判定合理：**
+
+- `discovery.rs:95,130,137` — `serde_json::to_string(&msg).unwrap()` — 序列化已知 enum variant，不會失敗
+- `main.rs:25,36` — tracing filter parse unwrap — 啟動初始化，固定字串
+- `server/main.rs:68,74` — TcpListener::bind/serve unwrap — server 啟動必要步驟，失敗應立即 panic
+- `client/main.rs:20,39,65` — rustls/runtime/eframe expect — 啟動必要步驟
+
+---
+
+## D-VALID: 輸入驗證缺口
+
+### 定義
+
+WebSocket 訊息處理缺少 size/format 驗證、serde deserialize 未驗證、數值 parse 未驗證範圍、字串長度用 bytes 而非字元數。
+
+### 搜查方式
+
+```bash
+# WebSocket message 處理（是否有 size/format 驗證）
+grep -rn "Message::Text\|Message::Binary" . --include="*.rs" --exclude-dir=target
+
+# serde deserialize 是否有驗證
+grep -rn "serde::Deserialize\|#\[derive.*Deserialize" . --include="*.rs" --exclude-dir=target
+
+# 數值 parse 未驗證範圍
+grep -rn "\.parse::<\|from_str" . --include="*.rs" --exclude-dir=target
+
+# 字串長度驗證是否用 bytes 而非字元數（CJK 使用者會遇到）
+grep -rn "\.len() > MAX_\|\.len() >= MAX_" . --include="*.rs" --exclude-dir=target
+```
+
+**搜查狀態：** 待搜查
+
+### What grep can't find (Charter seed)
+
+- **業務語意驗證：** 欄位有格式檢查，但值在遊戲語境合理嗎？例如：max_players 設為 0 或 999、room_name 全空白
+- **跨欄位依賴：** war3_version 和 gameinfo 的相容性驗證
+
+Suggested Charter:
+```
+Target: WebSocket 訊息驗證 — 惡意或異常輸入
+Task: 送出格式正確但語意異常的 ClientMessage（超長暱稱、
+  不存在的 room_id、重複 Register），觀察 server 反應
+Timebox: 30 min
+Trigger: D-VALID 搜查完成
+```
+
+### 搜查結果
+
+（依[記錄格式](#搜查結果記錄格式)填寫）
+
+---
+
+## D-AUTH: 認證、授權與安全防線
+
+### 定義
+
+WebSocket 路由未保護、rate limit 不足或可繞過、IP 驗證漏洞、CORS 設定過寬、unsafe 使用。
+
+### 搜查方式
+
+```bash
+# WebSocket 路由處理
+grep -rn "\.route\|Router::new" . --include="*.rs" --exclude-dir=target
+
+# rate limit 相關
+grep -rn "rate\|limit\|throttle" . --include="*.rs" --exclude-dir=target
+
+# unsafe 使用
+grep -rn "unsafe " . --include="*.rs" --exclude-dir=target
+
+# IP 驗證 / header 信任
+grep -rn "X-Real-IP\|x-real-ip\|remote_addr\|peer_addr" . --include="*.rs" --exclude-dir=target
+
+# CORS 設定
+grep -rn "CorsLayer\|cors\|Access-Control" . --include="*.rs" --exclude-dir=target
+```
+
+**搜查狀態：** 已搜查（2026-04-07）
+
+### What grep can't find (Charter seed)
+
+- **rate limit 的正確性：** rate limiter 存在，但實作是否允許 burst？epoch boundary 是否有 2x burst 問題？
+- **IP spoofing：** X-Real-IP header 是否只信任 loopback？
+- **WebSocket impersonation：** `__web-viewer-` prefix 是否可被任意客戶端使用？
+
+Suggested Charter:
+```
+Target: 安全防線 — rate limit 和 IP 驗證
+Task: 模擬快速重連、burst messaging、IP header 偽造，
+  驗證 rate limiter 和 per-IP 限制是否有效
+Timebox: 30 min
+Trigger: D-AUTH 搜查完成
+```
+
+### 搜查結果
+
+**搜查範圍：** `crates/server/`（主要安全防線所在），共 ~15 個路由/rate/limit/CORS 命中
+
+**發現：**
+
+- #24 — `main.rs:54` CorsLayer::permissive() 安全模型未文件化
+- #25 — ws.rs rate limiter token bucket 允許 epoch boundary 2x burst
+
+**Low-risk observations：**
+
+- `__web-viewer-` prefix 可被任意客戶端使用，但後果是自我限制（120s auto-disconnect），不構成安全威脅
+
+**審查但判定合理：**
+
+- `/ws`, `/tunnel`, `/health` 三個路由都有適當的 rate limiting 和 per-IP 連線限制
+- X-Real-IP header 只在 loopback 連線時信任（`main.rs:82`），外部連線使用 peer_addr
+- 零 `unsafe` 使用 — 全 codebase 沒有任何 unsafe 區塊
+
+---
+
+## D-TYPE: 型別安全漏洞
+
+### 定義
+
+as 強制轉型可能溢出、transmute 使用、手動 pointer 操作。Rust 的型別系統已消除大部分問題，此類別聚焦於顯式繞過型別安全的模式。
+
+### 搜查方式
+
+```bash
+# as 強制轉型（可能溢出）
+grep -rn " as u\| as i\| as f" . --include="*.rs" --exclude-dir=target --exclude-dir=tests | grep -v "#\[cfg(test" | grep -v "#\[test"
+
+# transmute（極危險）
+grep -rn "transmute" . --include="*.rs" --exclude-dir=target
+
+# 手動 pointer 操作
+grep -rn "\*const \|\*mut " . --include="*.rs" --exclude-dir=target
+```
+
+**搜查狀態：** 待搜查
+
+### What grep can't find (Charter seed)
+
+- **語意型別正確性：** 編譯通過但型別在業務上有誤。例如：player_id 和 room_id 都是 String，可能混用
+
+Suggested Charter:
+```
+Target: 型別語意 — ID 和 String 的混用風險
+Task: 追蹤 player_id 和 room_id 在整個流程中的使用，
+  檢查是否有可能混用兩者導致邏輯錯誤
+Timebox: 30 min
+Trigger: D-TYPE 搜查完成
+```
+
+### 搜查結果
+
+（依[記錄格式](#搜查結果記錄格式)填寫）
+
+---
+
+## D-PERF: 效能問題
+
+### 定義
+
+clone() 過度使用、blocking 呼叫在 async 中、不必要的 allocation。
+
+### 搜查方式
+
+```bash
+# clone() 過度使用
+grep -rn "\.clone()" . --include="*.rs" --exclude-dir=target --exclude-dir=tests | grep -v "#\[cfg(test" | grep -v "#\[test"
+
+# 迴圈內的 allocations（手動輔助）
+# 步驟：先找所有迴圈位置，再逐一人工檢查是否有不必要的 allocation
+grep -rn "loop \{\|for .* in\|while " . --include="*.rs" --exclude-dir=target
+# 也可用 cargo clippy 的 perf lints 輔助：clippy::perf 群組
+
+# blocking 呼叫在 async 中
+grep -rn "std::thread::sleep\|std::fs::" . --include="*.rs" --exclude-dir=target
+```
+
+> **分類策略：** clone() 和 allocation patterns 命中數會很高。只建 Issue 給 hot path 中的問題（async loop、每幀執行的 UI code）。一次性初始化的 clone/allocation 記錄為「判定合理」。
+
+**搜查狀態：** 待搜查
+
+### What grep can't find (Charter seed)
+
+- **效能退化趨勢：** 5 個玩家時快，500 個玩家時 broadcast_state 的 O(n) clone 是否成為瓶頸？
+- **Lock contention：** RwLock 在高並發下的等待時間
+
+Suggested Charter:
+```
+Target: 高負載效能 — broadcast_state 在 500 玩家時的表現
+Task: 模擬高頻率 room 變更（join/leave），觀察 broadcast
+  延遲和 lock 等待時間
+Timebox: 30 min
+Trigger: D-PERF 搜查完成
+```
+
+### 搜查結果
+
+（依[記錄格式](#搜查結果記錄格式)填寫）
+
+---
+
+## D-EDGE: 邊界條件與資源限制
+
+### 定義
+
+數值溢出風險、空集合未處理、timeout 設定不當。
+
+### 搜查方式
+
+```bash
+# 數值溢出風險
+grep -rn "as u8\|as u16\|as i8\|as i16" . --include="*.rs" --exclude-dir=target
+
+# 空集合未處理
+grep -rn "\[0\]\|\.first()\|\.last()" . --include="*.rs" --exclude-dir=target
+
+# timeout 相關
+grep -rn "timeout\|Duration::" . --include="*.rs" --exclude-dir=target
+```
+
+**搜查狀態：** 待搜查
+
+### What grep can't find (Charter seed)
+
+- **全域上限邊界：** 500 玩家 / 200 房間上限到達時的行為，是否有 graceful degradation？
+- **時間邊界：** heartbeat timeout 和 cleanup interval 的交互，是否有 cleanup 把還活著的連線清掉的可能？
+
+Suggested Charter:
+```
+Target: 資源限制邊界 — 全域上限行為
+Task: 模擬接近 500 玩家上限、200 房間上限的情境，
+  觀察新連線被拒絕時的錯誤訊息和恢復行為
+Timebox: 30 min
+Trigger: D-EDGE 搜查完成
+```
+
+### 搜查結果
+
+（依[記錄格式](#搜查結果記錄格式)填寫）
+
+---
+
+## D-RACE: 競態條件與並發問題（自定義類別）
+
+### 定義
+
+RwLock/Mutex 使用不當、channel 通訊問題、Arc 共享狀態風險、tokio::select! 分支行為、spawn 後未 join。War3 大量使用 tokio async + mpsc + RwLock，這是最高風險區。
+
+### 搜查方式
+
+```bash
+# RwLock / Mutex 使用
+grep -rn "RwLock\|Mutex" . --include="*.rs" --exclude-dir=target
+grep -rn "\.lock()\|\.read()\.await\|\.write()\.await" . --include="*.rs" --exclude-dir=target
+
+# channel 使用
+grep -rn "mpsc::\|channel()\|\.send(\|\.recv(" . --include="*.rs" --exclude-dir=target
+
+# Arc 共享狀態
+grep -rn "Arc::new\|Arc::clone\|Arc<" . --include="*.rs" --exclude-dir=target
+
+# tokio::select! 分支
+grep -rn "tokio::select!\|select!" . --include="*.rs" --exclude-dir=target
+
+# spawn 後沒有 join
+grep -rn "tokio::spawn\|thread::spawn" . --include="*.rs" --exclude-dir=target
+```
+
+> **分類策略：**
+> - `tokio::select!` 搭配 JoinHandle arm 是結構化併發（安全），不需要追蹤。只標記沒有用 select! 管理的 fire-and-forget spawn。
+> - spawn() 命中：只建 Issue 給 JoinHandle 被丟棄且沒有 abort() 或 select! 的情況。
+> - Arc<> 命中：只建 Issue 給 Arc 在 async await 點跨越迴圈的情況。
+> - 特別注意 TOCTOU 模式：check-then-act 跨越了 await point（如 read lock check + 後續 write lock update）。
+
+**搜查狀態：** 待搜查
+
+### What grep can't find (Charter seed)
+
+D-RACE 的 grep pattern 能偵測 lock/channel/spawn 使用位置。它們**搜不到**：
+
+- **跨 lock 的邏輯不一致：** 兩個 RwLock 之間的操作順序是否保證一致性？例如：register_token 寫 token_bindings 和 upnp_pending 是兩個獨立 write
+- **TOCTOU 競態：** read lock 檢查條件後釋放，write lock 修改時條件可能已變。例如：JoinRoom 的 room_full 檢查
+- **Channel backpressure：** mpsc channel 滿時的 try_send 失敗是否影響遊戲流程？
+- **select! 取消安全性：** select! 取消一個 arm 時，被取消的 future 是否留下了不一致的狀態？
+
+Suggested Charter:
+```
+Target: 並發狀態一致性 — RwLock 和 channel 的交互
+Task: 追蹤 AppState 和 TunnelState 的所有 write 操作，
+  檢查是否有跨 await point 的 check-then-act 模式，
+  模擬高並發 JoinRoom 驗證 TOCTOU 風險
+Timebox: 30 min
+Trigger: D-RACE 搜查完成
+```
+
+### 搜查結果
+
+（依[記錄格式](#搜查結果記錄格式)填寫）
+
+---
+
+## 搜查執行紀錄
+
+| 日期 | 類別 | 命中數 | 發現/排除 | 備註 |
+| ---- | ---- | ------ | --------- | ---- |
+| 2026-04-07 | D-SILENT | ~110 | 1 發現 (#23), 2 low-risk, 7 判定合理 | 首輪搜查 |
+| 2026-04-07 | D-AUTH | ~15 | 2 發現 (#24, #25), 1 low-risk, 3 判定合理 | 首輪搜查 |
+| 2026-04-07 | D-RACE | — | 1 發現 (#21), 來自 autoplan eng review | 非 grep 搜查，autoplan 發現 |
+| 2026-04-07 | D-VALID | — | 1 發現 (#22), 來自 autoplan eng review | 非 grep 搜查，autoplan 發現 |
+
+---
+
+## See also
+
+- [discovery-strategy.md](./discovery-strategy.md) — 雙層模型：搜查手冊與 ET 如何互饋
+- [et-charter-template.md](./et-charter-template.md) — Charter 模板與 Quick Start
+- [README.md](./README.md) — 品質管理追蹤總覽
+
+---
+
+## 如何新增自定義類別
+
+當你的專案有特定領域的缺陷模式時，可以擴充搜查手冊。
+
+### 步驟
+
+1. 在[分類總覽](#分類總覽)表格新增一行
+2. 在本文件新增一個 `## D-XXXX: 類別名稱` 段落
+3. 填寫：定義、搜查方式（具體的 grep 指令）、搜查狀態
+4. 執行首次搜查，依[記錄格式](#搜查結果記錄格式)記錄結果

--- a/quality/discovery-strategy.md
+++ b/quality/discovery-strategy.md
@@ -1,0 +1,149 @@
+<!-- Adapted from hottim900/quality-tracker -->
+# 品質發現策略
+
+> **用途：** 定義品質系統的雙層發現模型 — AI 執行層（搜查手冊 grep）與人類判斷層（探索式測試 ET）。
+> 說明何時該用哪一層、兩層之間如何互饋，以及什麼問題只有人類才能發現。
+
+---
+
+## 雙層模型
+
+品質發現分為兩層，各自覆蓋不同類型的問題：
+
+```
+┌─────────────────────────────────────────────────┐
+│              品質發現策略                         │
+│                                                   │
+│  AI 執行層（搜查手冊）    人類判斷層（ET）         │
+│  ─────────────────────   ─────────────────────    │
+│  已知模式 → grep 搜查     未知模式 → 探索式測試   │
+│  可自動化、可重複         需要判斷力、創造力       │
+│  輸出：Issue + 搜查紀錄   輸出：Issue + 新 pattern │
+│                                                   │
+│            ◄── 互饋迴圈 ──►                       │
+│  ET 發現新 pattern → 加入搜查手冊                 │
+│  搜查手冊的盲區 → 產生 ET charter                 │
+└─────────────────────────────────────────────────┘
+```
+
+**AI 執行層** — 搜查手冊（[defect-taxonomy.md](./defect-taxonomy.md)）中的 grep pattern 能系統性地找出已知缺陷模式。這一層的強項是覆蓋率和可重複性：跑一次就掃完整個 codebase，不遺漏。
+
+**人類判斷層** — 探索式測試（Exploratory Testing, ET）處理搜查手冊無法覆蓋的問題。這些問題需要業務脈絡、使用者意圖判斷、或跨功能推理，不是 regex 能捕捉的。
+
+兩層之間的互饋迴圈是系統的核心價值：
+- ET session 發現的新 pattern，若符合[推廣標準](#pattern-推廣標準)，加入搜查手冊成為 grep pattern
+- 搜查手冊每個類別的「盲區」（grep 搜不到的東西），產生 ET [charter seed](./defect-taxonomy.md)，指引下一次 ET session
+
+---
+
+## 末端問題 — grep 永遠找不到的東西
+
+有四類問題本質上無法被自動化搜查發現。這些是 ET 的核心領域：
+
+| 類型 | 說明 | 範例 |
+| ---- | ---- | ---- |
+| **業務邊界條件** | 業務規則在極端情況下的行為 | 使用者封存最後一個分類時，系統該怎麼辦？ |
+| **意圖判斷** | 程式碼行為與設計意圖的偏差，需要理解「本來想做什麼」 | 排序演算法在相同分數時的順序是否符合使用者預期？ |
+| **生產環境獨特性** | 只在真實環境才會出現的問題 | 高峰期並發存取、第三方 API timeout、時區邊界 |
+| **Charter 定義** | 「我們該對什麼感到可疑」這個問題本身 | 新功能上線後，什麼樣的使用場景最可能出問題？ |
+
+這不是說 grep 沒用。grep 處理它擅長的部分（已知模式），ET 處理 grep 處理不了的部分（需要判斷力的問題）。兩者互補，不是替代。
+
+---
+
+## 何時用哪一層？
+
+```
+發現了一個可疑的地方？
+├── 能用 regex 表達嗎？
+│   ├── 是 → 先查搜查手冊是否已有對應類別
+│   │   ├── 有 → 用搜查手冊（AI 執行層）
+│   │   └── 無 → 新增類別到搜查手冊，再執行搜查
+│   └── 否 → 這是 ET 的領域
+│
+想主動找問題？
+├── 剛完成搜查手冊某類別的掃查？
+│   └── 是 → 該類別的 charter seed 就是下一步
+├── 有 root-cause:design 的 Issue？
+│   └── 是 → 設計缺陷 grep 找不到，用 ET 探索
+├── 有 escape:production 的 Issue？
+│   └── 是 → 自動化管道漏掉了，用 ET 探索
+├── 剛上線新功能但沒有對應的搜查覆蓋？
+│   └── 是 → 用 ET 探索新功能的邊界
+└── 同區域短期內出現 2+ 個 Issue？
+    └── 是 → 系統性問題，用 ET 探索根因
+```
+
+完整的 5 個 ET 觸發信號和操作流程見 `/quality` skill（SKILL.md）。
+
+---
+
+## 互饋迴圈
+
+### 方向 1：ET → 搜查手冊
+
+ET session 發現的問題，如果符合[推廣標準](#pattern-推廣標準)，應該被加入搜查手冊。這樣下次就不需要人類判斷，grep 就能自動找到。
+
+### 方向 2：搜查手冊 → ET
+
+搜查手冊每個 D-XXX 類別有一個「What grep can't find (Charter seed)」段落。這些 charter seed 描述了該類別的 grep pattern **搜不到**的具體問題，是 ET session 的起點。
+
+Charter seed 不是通用的「多做一些測試」。它們指出具體的盲區：哪些業務規則、跨功能互動、或隱含假設是 grep 覆蓋不到的。
+
+### Pattern 推廣標準
+
+ET 發現要成為搜查手冊的新 grep pattern，必須通過三個檢查：
+
+1. **可 regex 化？** — 能表達為 regex 嗎？如果不行，它留在 charter seed（未來 ET 的素材）
+2. **精確度夠？** — 在 codebase 上執行時，false positive 低於 20% 嗎？
+3. **跨專案有用？** — 對使用相同技術棧的其他專案也適用嗎？
+
+三項都通過 → 加入 D-XXX 類別的搜查方式。任一項不通過 → 記錄在 charter seed 的「What grep can't find」段落。
+
+---
+
+## ET 方法論
+
+本系統的 ET 方法基於 Session-Based Test Management (SBTM)，為單人/小團隊 + AI 開發場景簡化：
+
+- **Charter** — 一份輕量計畫，用 4T 欄位（Target, Task, Timebox, Trigger）定義探索範圍
+- **Session** — 一段有時間限制的聚焦探索（預設 30 分鐘）
+- **Session Report** — 記錄發現、時間分配、新 pattern
+
+Charter 模板和使用說明見 [et-charter-template.md](./et-charter-template.md)。
+
+---
+
+## 詞彙表
+
+| 術語 | 定義 |
+| ---- | ---- |
+| **Charter Seed** | 搜查手冊中每個 D-XXX 類別的「What grep can't find」段落。描述 grep 的盲區，作為 ET charter 的起點。 |
+| **Negative Space** | 搜查手冊 grep pattern 能搜到的東西，隱含定義了它搜不到的東西。這個「搜不到的空間」就是 negative space，也就是 ET 該去探索的地方。 |
+| **4T 欄位** | Charter 的四個結構欄位：Target（探索目標）、Task（做什麼）、Timebox（時間限制）、Trigger（觸發原因）。 |
+| **Pattern 推廣** | 將 ET 發現的問題轉化為搜查手冊的 grep pattern 的過程。需通過三項標準（可 regex 化、精確度、跨專案適用性）。 |
+| **雙層模型** | 品質發現的兩個互補層：AI 執行層（grep 搜查）和人類判斷層（ET 探索）。 |
+| **發現策略** | 系統性地決定「用什麼方法找問題」的框架。不只是找 bug，而是知道什麼方法適合找什麼類型的問題。 |
+| **末端問題** | 本質上無法被自動化發現的四類問題：業務邊界條件、意圖判斷、生產環境獨特性、charter 定義。 |
+
+---
+
+## 方法論來源
+
+| 來源 | 採用的概念 |
+| ---- | ---- |
+| Cem Kaner（ET 創始者, 1984） | 探索式測試的定義：同時設計、執行測試並從中學習 |
+| James Bach（SBTM） | Session-Based Test Management：charter + session + debrief 結構 |
+| Context-Driven School | 測試方法應隨情境調整，沒有「最佳實踐」只有「適合的實踐」 |
+
+> 完整的方法論來源和設計決策見 [quality-system-design-notes.md](./quality-system-design-notes.md)。
+
+---
+
+## See also
+
+- [et-charter-template.md](./et-charter-template.md) — Charter 模板與 Quick Start
+- [defect-taxonomy.md](./defect-taxonomy.md) — 搜查手冊（含各類別的 charter seed）
+- [README.md](./README.md) — 品質管理追蹤總覽
+- [quality-system-design-notes.md](./quality-system-design-notes.md) — 設計筆記與方法論來源
+- [examples/sparkle/et-charters.md](../examples/sparkle/et-charters.md) — 真實 ET 執行範例

--- a/quality/et-charter-template.md
+++ b/quality/et-charter-template.md
@@ -1,0 +1,138 @@
+<!-- Adapted from hottim900/quality-tracker -->
+# 探索式測試 Charter 模板
+
+> **用途：** 輕量的 SBTM (Session-Based Test Management) charter 模板。
+> 5 分鐘寫完一份 charter，30 分鐘執行一次 session。
+> 結果流入既有的 Issue 追蹤系統。
+
+---
+
+## Quick Start
+
+3 步開始你的第一次 ET session：
+
+1. **複製下方模板**，填入 4T 欄位
+2. **設定 30 分鐘計時器**，開始探索
+3. **記錄發現**，建 Issue（加上 `discovery-method:et-session` label）
+
+不確定 charter 要寫什麼？從搜查手冊的 [charter seed](./defect-taxonomy.md) 開始。每個 D-XXX 類別都有一段「What grep can't find」，那就是最好的探索起點。
+
+---
+
+## Charter 模板（4T 欄位）
+
+```markdown
+## ET Charter: [標題]
+
+**Target（目標）：** 要探索的系統區域或功能
+**Task（任務）：** 具體要做什麼、要尋找什麼
+**Timebox（時限）：** 30 min（預設，可依需要調整）
+**Trigger（觸發）：** 什麼原因讓你決定做這次 ET
+
+### Session Report
+
+**日期：** YYYY-MM-DD
+**實際耗時：** __ min（探索 __% / 調查 __% / 記錄 __%）
+
+#### 發現
+
+- [ ] Issue #__ — 描述
+
+#### 新 Pattern 發現
+
+- [ ] 可加入搜查手冊？（見 Pattern 推廣標準）
+
+#### 筆記
+
+自由記錄：觀察、疑問、後續想法
+```
+
+---
+
+## 複製即用範例
+
+以下是一份填寫完成的 charter，展示格式和內容的詳細程度：
+
+```markdown
+## ET Charter: 分類管理的業務邊界條件
+
+**Target（目標）：** 分類的 CRUD 操作，特別是刪除和封存
+**Task（任務）：** 探索「最後一個」的邊界：刪除最後分類、
+  移動所有項目到另一個分類後的空分類、並發操作同一分類
+**Timebox（時限）：** 30 min
+**Trigger（觸發）：** D-EDGE 搜查完成，grep 已覆蓋 schema
+  限制但業務規則邊界未測試
+
+### Session Report
+
+**日期：** 2026-04-01
+**實際耗時：** 35 min（探索 60% / 調查 25% / 記錄 15%）
+
+#### 發現
+
+- [ ] #42 — 封存最後一個分類後，「新增項目」的預設分類指向
+  已封存的分類，UI 無錯誤提示但 API 回傳 400
+
+#### 新 Pattern 發現
+
+- [ ] `archived` 狀態的 entity 被其他 entity 引用為預設值
+  → 可能可以用 grep 搜查：找出所有引用 `default` + entity
+  關聯的地方，檢查是否處理了 archived 狀態
+
+#### 筆記
+
+- 「最後一個」的邊界不只是空集合，還有「最後一個被引用的」
+- 並發操作沒有在這次 session 中重現問題，可能需要更大的
+  timebox 或不同的探索角度
+```
+
+---
+
+## 好 Charter vs. 壞 Charter
+
+| 好 Charter | 壞 Charter |
+| ---- | ---- |
+| Target 指向具體的功能或區域 | Target 是「整個應用程式」 |
+| Task 描述具體的探索動作 | Task 是「找 bug」 |
+| Trigger 連結到搜查手冊類別或具體事件 | 沒有 Trigger（隨意探索） |
+| 30 min timebox | 無時限，做到累為止 |
+
+---
+
+## Session 結果如何流入追蹤系統
+
+1. **發現的缺陷** → 建 Issue，加上 `discovery-method:et-session` label
+2. **新的 grep pattern** → 評估是否符合[推廣標準](./discovery-strategy.md#pattern-推廣標準)，符合就加入搜查手冊
+3. **Session 本身** → 建一個 Issue 記錄 session（標題如「ET Session: D-EDGE 業務邊界探索」），發現和筆記作為 comment。這樣所有 session 都有追蹤紀錄。
+
+---
+
+## 沒有發現怎麼辦？
+
+沒有發現不代表 session 失敗。可能的情況：
+
+- **系統在這個區域確實很穩健** — 記錄「未發現問題」和探索的範圍，這本身就是品質信號
+- **Charter 的 scope 太窄** — 下次擴大 Target 或換一個角度
+- **Charter 的 scope 太廣** — 30 分鐘不夠深入，下次縮小到更具體的功能
+- **探索方向錯了** — 檢查 charter seed，是否有更高風險的盲區未探索
+
+Session report 中記錄你探索了什麼、為什麼沒發現問題，這些資訊對未來的 charter 設計有價值。
+
+---
+
+## 技術棧適配
+
+搜查手冊中的 charter seed 以 TypeScript/React 為範例。適配到你的專案時：
+
+- 保留業務規則和跨功能互動的探索方向（這些是技術棧無關的）
+- 將技術特定的範例替換為你的技術棧的等價概念（例如 Zod schema → FluentValidation，React state → Blazor component state）
+- 完整的技術棧適配範例見 [examples/](../examples/)
+
+---
+
+## See also
+
+- [discovery-strategy.md](./discovery-strategy.md) — 雙層模型與互饋迴圈
+- [defect-taxonomy.md](./defect-taxonomy.md) — 搜查手冊（含各類別的 charter seed）
+- [README.md](./README.md) — 品質管理追蹤總覽
+- [examples/sparkle/et-charters.md](../examples/sparkle/et-charters.md) — 真實 ET 執行範例

--- a/quality/quality-system-design-notes.md
+++ b/quality/quality-system-design-notes.md
@@ -1,0 +1,123 @@
+<!-- Adapted from hottim900/quality-tracker -->
+# 品質管理追蹤體系設計筆記
+
+> 可移植到任何專案的品質管理追蹤方法論。
+> 基於 ODC、DORA、GitHub Label Taxonomy 等業界實踐，
+> 針對「單人/小團隊 + AI 開發」場景優化。
+
+---
+
+## 1. 設計原則
+
+### 1.1 核心目標
+
+為 **AI 輔助開發** 設計的品質追蹤系統，最高優先級是：
+
+1. **AI 可自主操作** — 每個工作流步驟都有明確指引，不依賴隱性知識
+2. **單一來源** — 每筆資料只存在一處，避免多處同步導致不一致
+3. **可擴展** — 從 8 項到 800 項，結構不需改變
+
+### 1.2 設計取捨
+
+| 決策             | 選擇                          | 放棄                | 理由                             |
+| ---------------- | ----------------------------- | ------------------- | -------------------------------- |
+| 追蹤機制         | GitHub/GitLab Issues + Labels   | Markdown 追蹤檔     | Issue tracker 原生支援搜尋、過濾、assign、自動 close、Board |
+| Dashboard 策略   | Issue Board + Label 過濾        | 手動維護統計/表格   | 零同步，Issue 狀態為 source of truth |
+| 發現機制         | `gh/glab issue list` + label 過濾 | `glob` + `grep`   | 語意查詢，不依賴檔案系統結構        |
+| 模板分類         | 四種 Issue 模板（YAML forms / markdown） | 一個模板 + 條件欄位 | GitHub YAML forms 提供下拉選單驗證   |
+| Metadata 編碼    | Label prefix（`type:` / `priority:` / `severity:`） | Markdown 表格欄位 | 可搜尋、可過濾、可統計              |
+| 優先級 vs 嚴重度 | 分離為兩組 label                | 合併為一個          | 「何時修」和「多嚴重」是不同維度 |
+| 內容重複         | canonical location + Issue 交叉引用 | 每處都完整記載  | 避免多處更新造成不一致           |
+
+---
+
+## 2. 分類體系
+
+### 2.1 五分類 + 決策樹
+
+完整決策樹見 [README.md 分類體系](./README.md#分類體系)。
+
+第四類 **Test Infrastructure** 追蹤測試覆蓋缺口與測試工具建設 — 與 Defect/Tech Debt 不同，TI 項目的產出是「新增測試」而非「修改產品程式碼」。決策樹中 TI 透過兩個路徑進入 — 有意識的妥協分支（測試面）和功能不完整分支（測試覆蓋缺口），因為測試缺口常被混入 Tech Debt 或 Feature Gap，獨立分類讓追蹤更精確。
+
+第五類 **Quality Gate** 獨立於決策樹 — 不是「要修的東西」，而是「防止 Defect / Tech Debt / Feature Gap 進入 codebase 的基礎設施」（例如架構測試、CI 品質關卡、搜查手冊）。TI 本身就是 Quality Gate 的一部分 — 補齊測試覆蓋就是在建立防線。
+
+---
+
+## 3. AI 效率優化設計
+
+這是本體系與一般品質追蹤最大的差異。每個設計決策都考慮 AI 的工作方式。
+
+### 3.1 發現性（AI 怎麼知道這個系統存在）
+
+在專案的 `CLAUDE.md`（或等效的 AI 指令檔）加入入口。參考 `CLAUDE.md.snippet`。
+
+### 3.2 完成步驟 Checklist（AI 防遺漏）
+
+SKILL.md 明確列出完成步驟（關閉 Issue + 填寫完成 comment + 檢查相依 + 更新 taxonomy）。AI 最常犯的錯就是改完原始碼但忘記更新追蹤狀態。
+
+### 3.3 待追蹤發現的行動指引
+
+明確告訴 AI「不要主動升級為正式項目」，避免 AI 過度主動地建立大量低優先級項目。
+
+### 3.4 連結與發現
+
+- **Issue → Taxonomy：** Defect Issue body 的「缺陷子類別」欄位記錄 D-XXX 代碼
+- **Taxonomy → Issue：** 搜查結果段落以 `#N` 格式記錄發現的 Issue（collocated）或 `owner/repo#N`（companion repo）
+
+### 3.5 AI 效率 Checklist（啟用品質系統時確認）
+
+| #   | 項目                                      | 驗證方式                                       |
+| --- | ----------------------------------------- | ---------------------------------------------- |
+| 1   | CLAUDE.md 有品質系統入口                  | `grep '品質' CLAUDE.md`                        |
+| 2   | SKILL.md 有「完成步驟」指引               | `grep '完成步驟' .claude/skills/quality/SKILL.md` |
+| 3   | README 有「快速查詢」section              | `grep '快速查詢' quality/README.md`            |
+| 4   | SKILL.md 完成步驟與 README 一致           | 比對兩處步驟數與內容                           |
+| 5   | Issue 模板已安裝（.github/ 或 .gitlab/）  | `ls .github/ISSUE_TEMPLATE/ 2>/dev/null \|\| ls .gitlab/issue_templates/` |
+| 6   | README 有「建立新項目」流程               | `grep '建立新項目' quality/README.md`          |
+| 7   | 「待追蹤發現」有行動指引                  | `grep 'AI 行動指引' quality/README.md`         |
+
+### 3.6 Issue-Native 遷移理由
+
+原系統使用 markdown 檔案（DEF-001.md 等）追蹤品質項目。遷移至 Issue/PR-native 的原因：
+
+| 面向 | Markdown 追蹤檔 | Issue/PR-Native |
+| ---- | -------------- | --------------- |
+| 搜尋與過濾 | `grep` 文字搜尋 | Label 語意過濾，原生 Board |
+| 協作 | 手動通知 | 原生 assign、comment、mention |
+| 狀態管理 | 手動改 metadata 表 | Open/Closed + label，PR 自動 close |
+| 統計 | 自訂 bash script | 平台原生 Insights / API |
+| 可移植性 | 零依賴（純 markdown） | 需要 GitHub/GitLab + CLI |
+| AI 操作 | 讀寫本地檔案 | 需要 `gh`/`glab` CLI |
+
+**已知 trade-off：**
+- Sweep checkbox 從 hook 強制驗證退化為 PR template 中的 honor-based checkbox（Issue-native 無對應的檔案層 hook 目標）
+- 統計腳本從離線可用變為需要 CLI 認證 + 網路
+- Companion repo 模式需使用 `owner/repo#N` 格式跨 repo 引用 Issue
+
+---
+
+## 4. 方法論來源
+
+| 來源                                                                                                                                               | 採用的概念                                               |
+| -------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| [Orthogonal Defect Classification (ODC)](https://en.wikipedia.org/wiki/Orthogonal_Defect_Classification)                                           | Root Cause 分類、Trigger（逃逸階段）、可重複的搜查模式   |
+| [DORA Metrics](https://dora.dev/guides/dora-metrics/)                                                                                              | Change Failure Rate 的概念 → 逃逸階段追蹤                |
+| [GitHub Label Taxonomy](https://robinpowered.com/blog/best-practice-system-for-organizing-and-tagging-github-issues)                               | 前綴式分類（type: / priority: / status:）                |
+| [Shift-Left Testing](https://www.sonarsource.com/resources/library/shift-left/)                                                                    | 搜查手冊 → 自動化防線的演進路徑                          |
+| [Escaped Defect Analysis](https://softwareengineeringauthority.com/index.php/tools/13-software-engineering-disciplines/14-escaped-defect-analysis) | 逃逸階段欄位設計                                         |
+| [Martin Fowler Tech Debt Quadrant](https://en.wikipedia.org/wiki/Technical_debt)                                                                   | Deliberate vs Inadvertent → 決策樹的「有意識的妥協」分支 |
+| [Cem Kaner — Exploratory Testing](https://en.wikipedia.org/wiki/Exploratory_testing) (1984)                                                        | ET 定義：同時設計、執行測試並從中學習；末端問題分類 |
+| [James Bach — Session-Based Test Management](https://www.satisfice.com/sbtm/)                                                                      | SBTM：charter + session + debrief 結構 → 4T 欄位模板 |
+| [Context-Driven School of Testing](https://context-driven-testing.com/)                                                                            | 測試方法隨情境調整 → 搜查手冊與 ET 互補的雙層模型 |
+
+---
+
+## 5. 雙層品質發現模型
+
+品質發現分為 AI 執行層（搜查手冊 grep）與人類判斷層（探索式測試 ET）。
+
+- **AI 執行層：** 系統性掃查已知缺陷模式，可自動化、可重複。搜查手冊（defect-taxonomy.md）是這一層的操作手冊。
+- **人類判斷層：** 處理 grep 搜不到的問題：業務邊界條件、意圖判斷、生產環境獨特性。探索式測試（ET）透過 charter 結構化地引導人類探索這些盲區。
+- **互饋迴圈：** ET 發現的新 pattern 可推廣為 grep pattern（需通過三項標準），搜查手冊的「盲區」（charter seed）產生 ET 探索目標。
+
+完整方法論見 [discovery-strategy.md](./discovery-strategy.md)。


### PR DESCRIPTION
## Summary

整合 `hottim900/quality-tracker` 模板到 war3-battle-tool，完成 Rust 適配和首輪品質搜查。

**基礎建設：**
- `quality/` 目錄：7 類缺陷分類（6 通用 + D-RACE 自定義），完整 Rust grep patterns
- `.claude/skills/quality/SKILL.md`：Claude Code `/quality` skill
- `.github/ISSUE_TEMPLATE/`：4 種 issue 模板
- `CLAUDE.md`：品質管理 snippet
- 31 個 GitHub Labels（type, priority, status, severity, cost, escape, root-cause, discovery-method）

**首輪搜查（D-SILENT + D-AUTH）：**
- #21 JoinRoom TOCTOU 競態條件（D-RACE, priority:high）
- #22 CJK 暱稱 .len() bytes vs chars（D-VALID, priority:high）
- #23 cmd_tx.send() 靜默丟棄使用者命令（D-SILENT, priority:medium）
- #24 CorsLayer::permissive() 安全模型未文件化（D-AUTH, priority:low）
- #25 Rate limiter epoch boundary burst（D-AUTH, priority:low）

**回溯標記：**
- #19 → type:test-infra + priority:medium
- #20 → type:feature-gap + priority:low

## Review History

- `/office-hours`：設計文件 APPROVED（2 輪對抗審查，14 個問題修正，9/10）
- `/autoplan`：CEO + Eng + DX 三階段自動審查（23 個自動決策，3 個跨階段主題）
- `/review`：2 個問題 auto-fixed（SKILL.md 斷鏈 + defect.yml 空選項）

## Test plan

- [x] `quality/` 目錄結構完整
- [x] `/quality` skill 可被觸發
- [x] GitHub Labels 已建立（31 個）
- [x] Issue templates 已安裝（4 種）
- [x] #19, #20 已回溯標記
- [x] D-SILENT + D-AUTH 搜查已執行，結果記錄在 taxonomy
- [x] 5 個 Issues (#21-#25) 已建立含正確 labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)