### PR TITLE
feat: 日誌系統測試 + 可調 ring buffer (#19, #20)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4377,6 +4377,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tokio-tungstenite 0.26.2",
  "tracing",

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -22,3 +22,6 @@ open = "5"
 quinn = "0.11"
 rcgen = "0.13"
 igd-next = { version = "0.15", features = ["aio_tokio"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/client/src/app.rs
+++ b/crates/client/src/app.rs
@@ -147,6 +147,7 @@ impl War3App {
         cc.egui_ctx.set_style(style);
 
         let needs_wizard = !config.is_configured();
+        let log_buffer_size = config.log_buffer_size;
         let (tunnel_event_tx, tunnel_event_rx) = mpsc::unbounded_channel();
         let (upnp_mapped_tx, upnp_mapped_rx) = mpsc::unbounded_channel();
 
@@ -171,7 +172,7 @@ impl War3App {
                 None
             },
             lobby: LobbyPanel::new(),
-            log_panel: LogPanel::new(),
+            log_panel: LogPanel::new(log_buffer_size),
             log_tab: LogTab::Log,
             pending_action: None,
             pending_gameinfo: None,

--- a/crates/client/src/config.rs
+++ b/crates/client/src/config.rs
@@ -6,6 +6,10 @@ use war3_protocol::war3::War3Version;
 
 const CONFIG_FILENAME: &str = "war3-battle-tool.json";
 
+pub(crate) const LOG_BUFFER_MIN: usize = 1000;
+pub(crate) const LOG_BUFFER_MAX: usize = 5000;
+pub(crate) const LOG_BUFFER_DEFAULT: usize = 2000;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppConfig {
     pub nickname: String,
@@ -14,10 +18,17 @@ pub struct AppConfig {
     /// 本地 IP，用於封包注入目標（loopback 或真實網卡 IP）
     #[serde(default = "default_local_ip")]
     pub local_ip: String,
+    /// LogPanel ring buffer 大小（1000-5000）
+    #[serde(default = "default_log_buffer_size")]
+    pub log_buffer_size: usize,
 }
 
 fn default_local_ip() -> String {
     "127.0.0.1".into()
+}
+
+fn default_log_buffer_size() -> usize {
+    LOG_BUFFER_DEFAULT
 }
 
 impl Default for AppConfig {
@@ -28,6 +39,7 @@ impl Default for AppConfig {
             server_url: std::env::var("SERVER_URL")
                 .unwrap_or_else(|_| "wss://war3.kalthor.cc/ws".into()),
             local_ip: default_local_ip(),
+            log_buffer_size: default_log_buffer_size(),
         }
     }
 }
@@ -41,9 +53,24 @@ impl AppConfig {
 
     pub fn load() -> Self {
         let path = Self::config_path();
-        match std::fs::read_to_string(&path) {
+        let mut cfg: Self = match std::fs::read_to_string(&path) {
             Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
             Err(_) => Self::default(),
+        };
+        cfg.normalize();
+        cfg
+    }
+
+    /// 將手動編輯過的設定值夾到允許範圍，避免下游模組需要每次都防禦。
+    fn normalize(&mut self) {
+        let original = self.log_buffer_size;
+        self.log_buffer_size = self.log_buffer_size.clamp(LOG_BUFFER_MIN, LOG_BUFFER_MAX);
+        if self.log_buffer_size != original {
+            tracing::warn!(
+                verbosity = "concise",
+                "log_buffer_size {original} 超出 {LOG_BUFFER_MIN}-{LOG_BUFFER_MAX}，已調整為 {}",
+                self.log_buffer_size
+            );
         }
     }
 
@@ -60,5 +87,40 @@ impl AppConfig {
     /// 是否已完成首次設定（有暱稱）
     pub fn is_configured(&self) -> bool {
         !self.nickname.trim().is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_clamps_oversize_log_buffer() {
+        let mut cfg = AppConfig {
+            log_buffer_size: 999_999,
+            ..AppConfig::default()
+        };
+        cfg.normalize();
+        assert_eq!(cfg.log_buffer_size, LOG_BUFFER_MAX);
+    }
+
+    #[test]
+    fn normalize_clamps_undersize_log_buffer() {
+        let mut cfg = AppConfig {
+            log_buffer_size: 0,
+            ..AppConfig::default()
+        };
+        cfg.normalize();
+        assert_eq!(cfg.log_buffer_size, LOG_BUFFER_MIN);
+    }
+
+    #[test]
+    fn normalize_leaves_in_range_value_untouched() {
+        let mut cfg = AppConfig {
+            log_buffer_size: 3000,
+            ..AppConfig::default()
+        };
+        cfg.normalize();
+        assert_eq!(cfg.log_buffer_size, 3000);
     }
 }

--- a/crates/client/src/logging.rs
+++ b/crates/client/src/logging.rs
@@ -183,6 +183,68 @@ where
     }
 }
 
+// ── File writer ────────────────────────────────────────────
+
+/// 預設 log 目錄：`{data_dir}/war3-battle-tool/logs`。
+/// 回傳 None 表示作業系統未提供 data_dir（極罕見的 headless 環境）。
+pub fn default_log_dir() -> Option<std::path::PathBuf> {
+    dirs::data_dir().map(|d| d.join("war3-battle-tool").join("logs"))
+}
+
+/// 在 `log_dir` 建立 session log 檔案，回傳 mutex 包住的 File。
+/// 失敗回傳 None（caller 應 fallback：不附加 file layer，程式照樣啟動）。
+///
+/// 行為：先 `create_dir_all` 確保目錄存在、清理舊 log（保留 `keep_files` 個）、
+/// 再建立檔名為 `war3-<timestamp>.log` 的新檔。
+pub fn setup_file_writer(
+    log_dir: &std::path::Path,
+    keep_files: usize,
+) -> Option<std::sync::Mutex<std::fs::File>> {
+    if let Err(e) = std::fs::create_dir_all(log_dir) {
+        eprintln!("無法建立 log 目錄 {}: {e}", log_dir.display());
+        return None;
+    }
+
+    cleanup_old_logs(log_dir, keep_files);
+
+    let now = chrono::Local::now();
+    // 毫秒精度避免同秒兩個 instance 啟動時覆寫對方 log（崩潰立刻重啟情境）
+    let filename = format!("war3-{}.log", now.format("%Y-%m-%dT%H-%M-%S%.3f"));
+    let filepath = log_dir.join(&filename);
+
+    match std::fs::File::create(&filepath) {
+        Ok(f) => Some(std::sync::Mutex::new(f)),
+        Err(e) => {
+            eprintln!("無法建立 log 檔案 {}: {e}", filepath.display());
+            None
+        }
+    }
+}
+
+/// 保留 log 目錄中最新的 `keep` 個 .log 檔案，刪除其餘。
+fn cleanup_old_logs(log_dir: &std::path::Path, keep: usize) {
+    let mut logs: Vec<_> = std::fs::read_dir(log_dir)
+        .into_iter()
+        .flatten()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "log"))
+        .filter_map(|e| {
+            let modified = e.metadata().ok()?.modified().ok()?;
+            Some((modified, e.path()))
+        })
+        .collect();
+
+    if logs.len() <= keep {
+        return;
+    }
+
+    logs.sort_by_key(|(t, _)| *t);
+
+    for (_, path) in &logs[..logs.len() - keep] {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
 // ── Tests ──────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -281,6 +343,42 @@ mod tests {
 
         let entry = rx.try_recv().expect("should receive log entry");
         assert_eq!(entry.message, "已處理 42 筆");
+    }
+
+    // ── File writer tests ──
+
+    #[test]
+    fn test_file_layer_creates_file() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let log_dir = tmp.path().join("logs");
+        let writer = setup_file_writer(&log_dir, 30);
+        assert!(writer.is_some(), "writer should be created");
+
+        let entries: Vec<_> = std::fs::read_dir(&log_dir)
+            .expect("read_dir")
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().is_some_and(|ext| ext == "log"))
+            .collect();
+        assert_eq!(entries.len(), 1, "exactly one .log file should be created");
+
+        let name = entries[0].file_name();
+        let name_str = name.to_string_lossy();
+        assert!(
+            name_str.starts_with("war3-") && name_str.ends_with(".log"),
+            "filename pattern: got {name_str}"
+        );
+    }
+
+    #[test]
+    fn test_log_dir_failure_fallback() {
+        // 不可寫的父路徑：在已存在的檔案下建子目錄 → create_dir_all 必失敗
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let blocker = tmp.path().join("notadir");
+        std::fs::write(&blocker, b"file, not dir").expect("write blocker");
+        let bad_path = blocker.join("logs");
+
+        let writer = setup_file_writer(&bad_path, 30);
+        assert!(writer.is_none(), "fallback should return None, not panic");
     }
 
     #[test]

--- a/crates/client/src/main.rs
+++ b/crates/client/src/main.rs
@@ -32,11 +32,13 @@ fn main() {
 
     // File layer：寫入 {data_dir}/war3-battle-tool/logs/war3-{timestamp}.log
     // Option<L> 自動實作 Layer，None 時等於不加
-    let file_layer = setup_file_writer().map(|writer| {
-        tracing_subscriber::fmt::layer()
-            .with_writer(writer)
-            .with_ansi(false)
-    });
+    let file_layer = logging::default_log_dir()
+        .and_then(|dir| logging::setup_file_writer(&dir, 30))
+        .map(|writer| {
+            tracing_subscriber::fmt::layer()
+                .with_writer(writer)
+                .with_ansi(false)
+        });
 
     // env_filter 只套用在 terminal fmt layer，UI 和 file layer 接收所有 war3_client events
     let subscriber = tracing_subscriber::registry()
@@ -87,55 +89,4 @@ fn main() {
         }),
     )
     .expect("eframe 啟動失敗");
-}
-
-/// 建立 log 檔案 writer，回傳 None 表示 log 目錄/檔案建立失敗（程式繼續運行）。
-fn setup_file_writer() -> Option<std::sync::Mutex<std::fs::File>> {
-    let log_dir = dirs::data_dir()?.join("war3-battle-tool").join("logs");
-
-    if let Err(e) = std::fs::create_dir_all(&log_dir) {
-        eprintln!("無法建立 log 目錄 {}: {e}", log_dir.display());
-        return None;
-    }
-
-    // 清理舊 log：保留最近 30 個
-    cleanup_old_logs(&log_dir, 30);
-
-    // 建立 session log 檔案：war3-2026-04-07T12-30-01.log
-    let now = chrono::Local::now();
-    let filename = format!("war3-{}.log", now.format("%Y-%m-%dT%H-%M-%S"));
-    let filepath = log_dir.join(&filename);
-
-    match std::fs::File::create(&filepath) {
-        Ok(f) => Some(std::sync::Mutex::new(f)),
-        Err(e) => {
-            eprintln!("無法建立 log 檔案 {}: {e}", filepath.display());
-            None
-        }
-    }
-}
-
-/// 保留 log 目錄中最新的 `keep` 個 .log 檔案，刪除其餘。
-fn cleanup_old_logs(log_dir: &std::path::Path, keep: usize) {
-    let mut logs: Vec<_> = std::fs::read_dir(log_dir)
-        .into_iter()
-        .flatten()
-        .filter_map(|e| e.ok())
-        .filter(|e| e.path().extension().is_some_and(|ext| ext == "log"))
-        .filter_map(|e| {
-            let modified = e.metadata().ok()?.modified().ok()?;
-            Some((modified, e.path()))
-        })
-        .collect();
-
-    if logs.len() <= keep {
-        return;
-    }
-
-    // 按修改時間排序（新的在後）
-    logs.sort_by_key(|(t, _)| *t);
-
-    for (_, path) in &logs[..logs.len() - keep] {
-        let _ = std::fs::remove_file(path);
-    }
 }

--- a/crates/client/src/ui/log_panel.rs
+++ b/crates/client/src/ui/log_panel.rs
@@ -1,9 +1,8 @@
 use eframe::egui;
 use std::collections::VecDeque;
 
+use crate::config::{LOG_BUFFER_MAX, LOG_BUFFER_MIN};
 use crate::logging::{LogEntry, LogLevel, Verbosity};
-
-const MAX_LOG_ENTRIES: usize = 2000;
 
 pub struct LogPanel {
     entries: VecDeque<LogEntry>,
@@ -11,20 +10,21 @@ pub struct LogPanel {
     verbosity_filter: Verbosity,
     search_query: String,
     search_active: bool,
+    max_entries: usize,
 }
 
 impl LogPanel {
-    pub fn new() -> Self {
+    pub fn new(max_entries: usize) -> Self {
         Self {
             entries: VecDeque::new(),
             filtered_indices: Vec::new(),
             verbosity_filter: Verbosity::Concise,
             search_query: String::new(),
             search_active: false,
+            max_entries: max_entries.clamp(LOG_BUFFER_MIN, LOG_BUFFER_MAX),
         }
     }
 
-    /// 從 UiLogLayer channel 接收 LogEntry
     /// 從 UiLogLayer channel 接收 LogEntry
     pub fn push(&mut self, entry: LogEntry) {
         let passes = self.entry_passes_filter(&entry);
@@ -32,7 +32,7 @@ impl LogPanel {
 
         // Ring buffer 溢出：pop 多餘的，最後只 rebuild 一次
         let mut evicted = false;
-        while self.entries.len() > MAX_LOG_ENTRIES {
+        while self.entries.len() > self.max_entries {
             self.entries.pop_front();
             evicted = true;
         }
@@ -126,10 +126,20 @@ impl LogPanel {
                         ui.close_menu();
                     }
                     if ui.button("開啟 Log 資料夾").clicked() {
-                        if let Some(log_dir) =
-                            dirs::data_dir().map(|d| d.join("war3-battle-tool").join("logs"))
-                        {
-                            let _ = open::that(&log_dir);
+                        match crate::logging::default_log_dir() {
+                            Some(log_dir) => {
+                                if let Err(e) = open::that(&log_dir) {
+                                    tracing::warn!(
+                                        verbosity = "concise",
+                                        "無法開啟 log 資料夾 {}: {e}",
+                                        log_dir.display()
+                                    );
+                                }
+                            }
+                            None => tracing::warn!(
+                                verbosity = "concise",
+                                "找不到使用者 data 目錄，無法定位 log 資料夾"
+                            ),
                         }
                         ui.close_menu();
                     }
@@ -140,7 +150,7 @@ impl LogPanel {
         ui.separator();
 
         // Ring buffer 溢出提示
-        if self.entries.len() == MAX_LOG_ENTRIES {
+        if self.entries.len() == self.max_entries {
             ui.colored_label(
                 egui::Color32::from_rgb(0x64, 0x6c, 0x80),
                 egui::RichText::new("已省略較舊日誌").size(11.0),
@@ -186,5 +196,92 @@ impl LogPanel {
                     }
                 }
             });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::LOG_BUFFER_DEFAULT;
+
+    fn entry(message: &str, verbosity: Verbosity, level: LogLevel) -> LogEntry {
+        LogEntry {
+            timestamp: "00:00:00".into(),
+            message: message.into(),
+            level,
+            verbosity,
+            module: "war3_client::test".into(),
+        }
+    }
+
+    #[test]
+    fn test_ring_buffer_overflow() {
+        let mut panel = LogPanel::new(LOG_BUFFER_DEFAULT);
+        for i in 0..LOG_BUFFER_DEFAULT + 1 {
+            panel.push(entry(
+                &format!("msg {i}"),
+                Verbosity::Concise,
+                LogLevel::Info,
+            ));
+        }
+        assert_eq!(panel.entries.len(), LOG_BUFFER_DEFAULT);
+        // 最舊的被淘汰，最新的留著
+        assert_eq!(panel.entries.front().unwrap().message, "msg 1");
+        assert_eq!(
+            panel.entries.back().unwrap().message,
+            format!("msg {}", LOG_BUFFER_DEFAULT)
+        );
+        // 確認 evicted 路徑也有 rebuild filtered_indices（不只是 entries）
+        assert_eq!(panel.filtered_indices.len(), LOG_BUFFER_DEFAULT);
+    }
+
+    #[test]
+    fn test_filtered_indices_update() {
+        let mut panel = LogPanel::new(LOG_BUFFER_DEFAULT);
+        // 預設 filter = Concise，只收 Concise
+        panel.push(entry("a", Verbosity::Concise, LogLevel::Info));
+        panel.push(entry("b", Verbosity::Detailed, LogLevel::Info));
+        panel.push(entry("c", Verbosity::Full, LogLevel::Info));
+        assert_eq!(panel.filtered_indices.len(), 1);
+
+        // 切到 Detailed：Concise + Detailed 都看得到
+        panel.verbosity_filter = Verbosity::Detailed;
+        panel.rebuild_filtered_indices();
+        assert_eq!(panel.filtered_indices.len(), 2);
+
+        // 切到 Full：全部看得到
+        panel.verbosity_filter = Verbosity::Full;
+        panel.rebuild_filtered_indices();
+        assert_eq!(panel.filtered_indices.len(), 3);
+    }
+
+    #[test]
+    fn test_search_filter() {
+        let mut panel = LogPanel::new(LOG_BUFFER_DEFAULT);
+        panel.verbosity_filter = Verbosity::Full;
+        panel.push(entry("Tunnel 已連線", Verbosity::Concise, LogLevel::Info));
+        panel.push(entry("加入房間成功", Verbosity::Concise, LogLevel::Info));
+        panel.push(entry("Tunnel 中斷", Verbosity::Detailed, LogLevel::Warn));
+
+        panel.search_query = "Tunnel".into();
+        panel.rebuild_filtered_indices();
+        assert_eq!(panel.filtered_indices.len(), 2);
+        // 確認過濾出的真的都含關鍵字
+        for idx in &panel.filtered_indices {
+            assert!(panel.entries[*idx].message.contains("Tunnel"));
+        }
+    }
+
+    #[test]
+    fn test_buffer_size_clamped_to_range() {
+        // 超出上限 → 夾到 5000
+        let panel = LogPanel::new(99999);
+        assert_eq!(panel.max_entries, LOG_BUFFER_MAX);
+        // 低於下限 → 夾到 1000
+        let panel = LogPanel::new(10);
+        assert_eq!(panel.max_entries, LOG_BUFFER_MIN);
+        // 範圍內 → 原值
+        let panel = LogPanel::new(3000);
+        assert_eq!(panel.max_entries, 3000);
     }
 }

--- a/crates/client/src/ui/settings.rs
+++ b/crates/client/src/ui/settings.rs
@@ -1,6 +1,6 @@
 use eframe::egui;
 
-use crate::config::AppConfig;
+use crate::config::{AppConfig, LOG_BUFFER_MAX, LOG_BUFFER_MIN};
 
 /// 設定面板
 pub fn show(ui: &mut egui::Ui, config: &mut AppConfig, config_changed: &mut bool) {
@@ -35,6 +35,20 @@ pub fn show(ui: &mut egui::Ui, config: &mut AppConfig, config_changed: &mut bool
             if ui
                 .text_edit_singleline(&mut config.local_ip)
                 .on_hover_text("封包注入的目標 IP（通常為 127.0.0.1 或真實網卡 IP）")
+                .changed()
+            {
+                *config_changed = true;
+            }
+            ui.end_row();
+
+            ui.label("日誌緩衝大小：");
+            let slider =
+                egui::Slider::new(&mut config.log_buffer_size, LOG_BUFFER_MIN..=LOG_BUFFER_MAX)
+                    .step_by(500.0)
+                    .suffix(" 筆");
+            if ui
+                .add(slider)
+                .on_hover_text("LogPanel 保留的最近訊息數，重啟後生效")
                 .changed()
             {
                 *config_changed = true;


### PR DESCRIPTION
## Summary

- **#19** 補 9 個 log 系統測試（log_panel × 4、logging × 2、config × 3）
- **#20** 設定頁可調 LogPanel ring buffer（1000-5000，step 500）
- 順手整理：file writer 移到 logging.rs（測試友善）、新增 `default_log_dir()` 去重路徑、log 檔名加毫秒精度避免同秒覆寫、修正 config→ui 反向依賴

## 改動

- `crates/client/Cargo.toml` — `[dev-dependencies] tempfile = \"3\"`
- `crates/client/src/config.rs` — 加 `log_buffer_size` 欄位、`LOG_BUFFER_MIN/MAX/DEFAULT` 常量、`AppConfig::normalize()` 在 load 時 clamp + `tracing::warn`
- `crates/client/src/logging.rs` — 新增 `default_log_dir()` 與 `setup_file_writer(log_dir, keep_files)`、2 個 integration tests
- `crates/client/src/main.rs` — 用新 logging API
- `crates/client/src/ui/log_panel.rs` — `LogPanel::new(max_entries)` 接受 config 值、4 個 unit tests、「開啟 Log 資料夾」失敗 warn
- `crates/client/src/ui/settings.rs` — Slider 1000-5000
- `crates/client/src/app.rs` — 傳 `config.log_buffer_size` 給 `LogPanel::new`

## Test plan

- [x] `cargo test --package war3-client` — 41 + 4 + 2 全綠（+9 新測試）
- [x] `cargo clippy --workspace --exclude spike-packet -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [ ] 手動驗證：設定頁拉滑桿、儲存、重啟、確認 LogPanel 容量改變

Closes #19
Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)