### PR TITLE
docs: server 安全模型補完 — CORS / rate limit / X-Real-IP (#24, #25)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,10 +47,13 @@ cargo build --release --package war3-client  # Windows only
 ## Server 安全模型
 
 - IP 不再交換。雙方都連 localhost，透過 tunnel relay 通訊
-- /ws: 每 IP 3 連線、每連線 10 msg/s、訊息 ≤ 4KB
+- /ws: 每 IP 10 連線、每連線 10 msg/s、訊息 ≤ 4KB
 - /tunnel: 每 IP 12 連線、per-tunnel 50 KB/s rate limit、30s pairing timeout
 - Join 冷卻 5 秒、全域 500 玩家 / 200 房間上限
 - TunnelState 與 AppState 使用獨立 RwLock，避免 lock contention
+- **CORS**：`CorsLayer::permissive()` 套在 Router 全域，主要對 `/health` 等 HTTP endpoint 生效；瀏覽器 WebSocket 升級不走 CORS preflight，安全來自無 cookie/session/CSRF（連線本身就是認證）+ 後續訊息限流。**新增任何 endpoint 前須評估**——目前的寬鬆設定是 web viewer 場景的明示選擇。
+- **/ws rate limiter**：fixed-window（每秒重填），window 邊界允許短暫 2× burst。單 IP 上限：每連線 10 msg/s × 10 連線 ≈ 100 msg/s 穩態、邊界期 200 msg/60ms。已知設計選擇；訊息大小 4KB + 全域玩家/房間上限限制 state，nginx 層另有頻寬限制。詳見 `ws.rs` `RateLimiter` doc。
+- **X-Real-IP 信任邊界**：server bind `127.0.0.1` 且僅信任 loopback 連線送來的 `X-Real-IP`。**部署不變式**：若改 bind 到 `0.0.0.0` 用於測試，必須移除 `X-Real-IP` 信任邏輯，否則任何 client 都能透過 header 偽造 IP 繞過 per-IP 限制。
 
 ## 部署
 

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -51,6 +51,9 @@ async fn main() {
         .route("/ws", get(ws_handler))
         .route("/tunnel", get(tunnel_handler))
         .route("/health", get(|| async { "ok" }))
+        // 全域 permissive：對 /health 等 HTTP endpoint 生效；
+        // WebSocket 升級不走 CORS preflight，安全來自連線後限流 + 訊息協定
+        // 新增 endpoint 前須評估，詳見 CLAUDE.md「Server 安全模型」
         .layer(CorsLayer::permissive())
         .with_state(shared);
 

--- a/crates/server/src/ws.rs
+++ b/crates/server/src/ws.rs
@@ -20,6 +20,14 @@ const JOIN_COOLDOWN: Duration = Duration::from_secs(5);
 const WEB_VIEWER_TIMEOUT: Duration = Duration::from_secs(120);
 const WEB_VIEWER_PREFIX: &str = "__web-viewer-";
 
+/// 每連線訊息頻率限制（fixed-window，1 秒重填一次）。
+///
+/// 已知行為（#25）：在 window 邊界允許短暫 2× burst——客戶端可以在 t=0.95
+/// 發 10 條（耗光 token），等到 t=1.01 重填後再發 10 條，於 0.06 秒內共 20 條。
+/// 故意保留此設計：
+/// - per-IP 連線上限 + 訊息大小 4KB + 全域玩家/房間數已防止資源耗盡
+/// - 真正的 sliding-window 或 leaky bucket 需多存 state，邊際效益不足
+/// - 用 instant.elapsed() 而非 wall clock，避開系統時鐘跳動問題
 struct RateLimiter {
     tokens: u32,
     last_refill: Instant,


### PR DESCRIPTION
## Summary

純文件 PR，無程式邏輯改動。Close 兩個由品質首輪搜查發現、評估後**接受現狀**的 issues：

- **#25** 已知 rate limiter 2× burst 行為文件化（`RateLimiter` doc + CLAUDE.md）。Per-IP 連線數 + 訊息大小已防護，sliding-window/leaky-bucket 邊際效益不足。
- **#24** `CorsLayer::permissive()` 文件化。**並糾正 misleading 描述**：瀏覽器 WebSocket upgrade 不走 CORS preflight，permissive 主要對 `/health` 等 HTTP endpoint 生效。

伴隨補完：
- CLAUDE.md `/ws` per-IP 連線數從過時「3」改為現行「10」
- 加 X-Real-IP 信任邊界部署不變式（bind 0.0.0.0 須拔信任）

## Test plan

- [x] `cargo check --workspace --exclude spike-packet` clean
- [x] `cargo clippy --workspace --exclude spike-packet -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- 無新測試（純文件 PR）

Closes #24
Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)