### PR TITLE
chore: 修 rust 1.95.0 clippy::collapsible_match

### DIFF
--- a/crates/protocol/src/messages.rs
+++ b/crates/protocol/src/messages.rs
@@ -126,6 +126,9 @@ impl ServerMessage {
 
 impl ClientMessage {
     /// 驗證訊息欄位長度
+    // 保持每個 arm 都用 inline `if` 風格一致；JoinRoom 雖只有單一 if，
+    // 不單獨改成 match guard 以免視覺不對稱
+    #[allow(clippy::collapsible_match)]
     pub fn validate(&self) -> Result<(), &'static str> {
         match self {
             ClientMessage::Register { nickname, .. } => {


### PR DESCRIPTION
## Summary

Rust 1.95.0 把 `clippy::collapsible_match` lint 擴展到 match arm 內的 single-if，導致 `crates/protocol/src/messages.rs:162` (JoinRoom validation) 開始觸發 CI clippy fail，**任何新 PR 都會被擋**。

加 `#[allow]` 並註明理由（其他 arm 多 if 不能用 guard，保持風格一致）。

## Test plan

- [x] `cargo clippy --workspace --exclude spike-packet -- -D warnings` clean
- [x] `cargo check --workspace --exclude spike-packet` clean

Unblocks: #28, #29, #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)