### PR TITLE
docs: 品質系統第二輪進化 — D-DOC 類別 + ET charters

### DIFF
--- a/quality/defect-taxonomy.md
+++ b/quality/defect-taxonomy.md
@@ -43,6 +43,7 @@
 | D-PERF   | 效能問題             | 全層          | 待搜查   |
 | D-EDGE   | 邊界條件與資源限制   | 全層          | 待搜查   |
 | D-RACE   | 競態條件與並發問題   | Server/Client | 待搜查   |
+| D-DOC    | 文件與實作不一致     | 全層          | 待搜查   |
 
 ---
 
@@ -408,6 +409,56 @@ Trigger: D-RACE 搜查完成
 
 ---
 
+## D-DOC: 文件與實作不一致
+
+### 定義
+
+CLAUDE.md、註解、PR description 等文件描述的行為與實作不符。包括：常數值過時（code 改了 doc 沒同步）、機制描述錯誤（如「CORS layer 保護 WebSocket」實際 WS 不走 CORS）、安全模型 caveat 未紀錄。
+
+對使用者的影響通常**間接**：下個維護者照文件做決策、引入新 bug 或誤判風險。
+
+### 搜查方式
+
+```bash
+# 常數值 vs 文件對齊：抓 code 內的數字 const，比對 doc 內出現的數字
+grep -rn "const MAX_\|const [A-Z_]\+: u\?\(8\|16\|32\|64\|size\) = [0-9]" . --include="*.rs" --exclude-dir=target
+# 然後在 CLAUDE.md / README.md 內查這些數字是否一致
+
+# inline 註解標示的「TODO/FIXME/XXX」是否與目前 code 一致
+grep -rn "TODO\|FIXME\|XXX\|HACK" . --include="*.rs" --include="*.md" --exclude-dir=target
+
+# 「為了 X 才這樣做」類註解：審查 X 是否還成立
+grep -rn "^[[:space:]]*//.*為了\|^[[:space:]]*//.*因為" . --include="*.rs" --exclude-dir=target
+```
+
+> **搜查策略：** 此類別的 grep 命中很多但 false positive 也多。建議 doc 改動 PR 觸發、或每季抽樣審 CLAUDE.md 內的具體數字 / 機制描述。
+
+**搜查狀態：** 待搜查
+
+### What grep can't find (Charter seed)
+
+- **misleading 措辭**：doc 寫「CORS layer 保護 WebSocket」聽起來合理但實際無效；grep 抓不到語意層級
+- **安全模型 caveat 缺漏**：例如「server bind 0.0.0.0 後 X-Real-IP 信任就是漏洞」這種部署 invariant
+- **隱含假設過時**：code 改了 protocol，但文件還在描述舊 protocol
+
+Suggested Charter:
+```
+Target: CLAUDE.md「Server 安全模型」段所述條目
+Task: 逐項驗證——找出 code 對應位置，確認數字、機制、行為皆吻合。
+  特別檢查 「per-IP 連線數」、「rate limit」、「CORS」、「X-Real-IP 信任邊界」。
+Timebox: 45 min
+Trigger: 重要 PR 修改安全相關 code 後
+```
+
+### 搜查結果
+
+**搜查範圍：** PR #30 順手對 CLAUDE.md「Server 安全模型」段做了一次手動審查
+**發現：**
+- #24/#25 已修：CORS 對 WebSocket 是 no-op 的 misleading 描述 + rate limit 真實上限未量化 + per-IP 連線數過時（3 → 10）
+- #34 新建：WebSocket Origin 驗證缺漏（從 CORS 文件化過程衍生發現）
+
+---
+
 ## 搜查執行紀錄
 
 | 日期 | 類別 | 命中數 | 發現/排除 | 備註 |
@@ -416,6 +467,8 @@ Trigger: D-RACE 搜查完成
 | 2026-04-07 | D-AUTH | ~15 | 2 發現 (#24, #25), 1 low-risk, 3 判定合理 | 首輪搜查 |
 | 2026-04-07 | D-RACE | — | 1 發現 (#21), 來自 autoplan eng review | 非 grep 搜查，autoplan 發現 |
 | 2026-04-07 | D-VALID | — | 1 發現 (#22), 來自 autoplan eng review | 非 grep 搜查，autoplan 發現 |
+| 2026-05-16 | D-DOC | — | 3 發現修復 (#24/#25 + CLAUDE.md 數字修正), 1 衍生 (#34) | PR #30 doc PR 過程手動審 |
+| 2026-05-16 | follow-up | — | 6 個 follow-up issues 建立 (#32-#37) | PR #28/29/30 review skipped items 整理 |
 
 ---
 

--- a/quality/et-sessions/2026-05-16-network-disruption.md
+++ b/quality/et-sessions/2026-05-16-network-disruption.md
@@ -1,0 +1,41 @@
+# ET Charter: 網路中斷與重連時 client 狀態一致性
+
+**Target（目標）：** Client 的 connection lifecycle — `ConnectionState`、`PendingAction`、`LogPanel`、`LobbyPanel` 在網路擾動下的一致性
+
+**Task（任務）：**
+故意觸發網路擾動，觀察 client UI 與內部狀態是否同步、是否有殘留 stale state。具體執行情境：
+
+1. **拔網路線/Wi-Fi 切 4G** — 連線中、Lobby 顯示房間時切斷
+2. **DNS 失敗** — 修改 hosts 把 `war3.kalthor.cc` 指向 127.0.0.1，重啟 client
+3. **Server 重啟** — pending join/create room 時 server 重啟，看 reconnect 行為
+4. **網路 flaky** — 用 `tc netem` 加 30% 封包丟失，玩到一半連線抖動
+5. **慢速網路** — 用 `tc netem` 加 500ms 延遲，看 pending banner 是否 stuck
+
+**Timebox（時限）：** 45 min（單一情境約 7-8 min × 5）
+
+**Trigger（觸發）：** PR #28 (cmd_tx silent drop fix) merge 後驗證 — `try_send_cmd` 修了「按按鈕沒反應」，但只在 receiver dropped 時生效。網路抖動還會引發其他 stale state 嗎？
+
+### 探索焦點（D-SILENT、D-DOC charter seeds 交集）
+
+- `pending_action: Joining/CreatingRoom` 在連線失敗時是否被清除？
+- `LogPanel` 是否在斷線時持續累積錯誤（影響 ring buffer 行為）？
+- `connection_state: Reconnecting { attempt }` 顯示的 attempt 數是否與實際嘗試吻合？
+- 重連成功後 `players` / `rooms` 是否會殘留斷線前的舊資料一段時間？
+- 「複製連結」按鈕在 host 房間掉線後仍可點，連結是否仍有效？
+
+### Session Report
+
+**日期：** （執行時填）
+**實際耗時：** __ min（探索 __% / 調查 __% / 記錄 __%）
+
+#### 發現
+
+- [ ] Issue #__ — 描述
+
+#### 新 Pattern 發現
+
+- [ ] 可加入搜查手冊？（D-XXXX 類別 / 新類別）
+
+#### 筆記
+
+（執行時自由記錄）

--- a/quality/et-sessions/2026-05-16-rapid-input.md
+++ b/quality/et-sessions/2026-05-16-rapid-input.md
@@ -1,0 +1,45 @@
+# ET Charter: 暴力輸入與奇怪字串
+
+**Target（目標）：** Client UI 對 rapid user input 與 edge-case 字串的反應 — `LobbyPanel`、`SetupWizard`、`Settings` 三個輸入點
+
+**Task（任務）：**
+故意製造異常輸入，觀察 client 是否有 UI 殘留、protocol 拒絕、或 server 端錯誤訊息被吞。具體：
+
+1. **暴力連點** — 「建立房間」連點 10 次、「加入」連點 5 次、設定頁滑桿快速拖拉
+2. **CJK / Emoji / RTL** — 暱稱輸入 `🎮War3傳奇王者⚔️`、`مرحبا`（阿拉伯文）、`Тест`（西里爾文）
+3. **長度邊界** — 暱稱 32 字元、33 字元、零寬空格、純空白
+4. **特殊字元** — 暱稱含 `<script>`、`'; DROP TABLE`、`\n` 換行符
+5. **Server URL 異常** — 設定頁填 `wss://nonexistent.invalid`、`http://localhost:9999`、空字串
+6. **房間名稱** — 用 War3 客戶端建房名為 emoji、超長、雙引號
+
+**Timebox（時限）：** 40 min
+
+**Trigger（觸發）：**
+- PR #29 (log buffer config) merge 後 — 設定頁加了滑桿，順便 stress test 整個設定頁
+- #22 修了 CJK 長度驗證但僅針對 protocol，UI 邊界未測
+
+### 探索焦點
+
+- **連點建房**：是否會建出多間自己的房間？UI 是否 disable 第二次按？
+- **服務端訊息錯誤**：server 回 `ServerMessage::Error` 時，client UI 是否顯示？還是只 log？（與 PR #28 的「使用者看不到失敗」相關）
+- **CJK 顯示**：egui 是否正確渲染所有字元？emoji 是否 fallback？
+- **設定頁** `local_ip` 填非法值（`abc.def`、`999.999.999.999`）能否儲存？儲存後重啟 crash 嗎？
+- **log buffer 滑桿** 拖拉時 `config_changed = true` 觸發頻率，是否每步都寫 disk（看 settings.rs:save 路徑）
+- **超長暱稱顯示** 在 lobby 卡片是否 truncate（v0.3.3 已加 .truncate()，驗證有效）
+
+### Session Report
+
+**日期：** （執行時填）
+**實際耗時：** __ min
+
+#### 發現
+
+- [ ] Issue #__ — 描述
+
+#### 新 Pattern 發現
+
+- [ ] 可加入搜查手冊？
+
+#### 筆記
+
+（執行時自由記錄）


### PR DESCRIPTION
## Summary

從 PR #28/#29/#30 整輪 multi-agent review 學到的 pattern 整理回品質系統。

### defect-taxonomy.md
- **新增 D-DOC 類別**「文件與實作不一致」：grep 模式（常數 vs 文件對齊、TODO/FIXME 審視、註解的「為了 X」是否仍成立）+ Charter seed（misleading 措辭、部署 invariant 漏寫、隱含假設過時）
- **搜查執行紀錄**追加 2 筆（PR #30 doc-driven 手動審、follow-up issues 整理）

### quality/et-sessions/ 新增 2 個 charter（待人類執行）
- `2026-05-16-network-disruption.md` — 5 個網路擾動情境，驗證 PR #28 修復覆蓋面、找其他 stale state
- `2026-05-16-rapid-input.md` — 6 個輸入 vector（連點、CJK/emoji/RTL、長度邊界、特殊字元），stress test 設定頁/lobby/wizard 三個輸入點

## Test plan

純 doc PR，無程式改動，CI 應通過。Charter 由人類執行（30-45 min/session）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)