### PR TITLE
fix: 連線斷開時清 stale state + ServerMessage::Error 顯示 UI banner (#40 #41)

### DIFF
--- a/crates/client/src/app.rs
+++ b/crates/client/src/app.rs
@@ -51,6 +51,17 @@ enum PendingAction {
     ServerError { message: String },
 }
 
+impl PendingAction {
+    /// Whether this action is awaiting a server response (spinner showing).
+    /// 用來判斷連線中斷/錯誤訊息進來時是否該取消當前操作。
+    fn is_in_flight(&self) -> bool {
+        matches!(
+            self,
+            PendingAction::Joining { .. } | PendingAction::CreatingRoom { .. }
+        )
+    }
+}
+
 pub struct War3App {
     config: crate::config::AppConfig,
     config_changed: bool,
@@ -340,6 +351,11 @@ impl War3App {
                 NetEvent::Connected => {
                     self.connection_state = ConnectionState::Connected;
                     self.ever_connected = true;
+                    // 重連成功後清掉斷線時設的 stale ServerError，避免「● 已連線」+
+                    // 紅 banner「中斷連線」自相矛盾
+                    if matches!(self.pending_action, Some(PendingAction::ServerError { .. })) {
+                        self.pending_action = None;
+                    }
                     tracing::info!(verbosity = "concise", "已連線到發現伺服器");
 
                     if !self.is_registered() && self.config.is_configured() {
@@ -349,30 +365,30 @@ impl War3App {
                 NetEvent::Disconnected => {
                     self.connection_state = ConnectionState::Disconnected;
                     self.my_player_id = None;
-                    // 重置斷線時的 stale state，避免「線上 N 人 + 舊房間列表」幻覺
                     self.players.clear();
                     self.rooms.clear();
-                    // 進行中的動作 (Joining/CreatingRoom) 在 transport 失敗時永遠收不到
-                    // server response，把 banner 換成失敗訊息避免 spinner 卡死
-                    if matches!(
-                        self.pending_action,
-                        Some(PendingAction::Joining { .. } | PendingAction::CreatingRoom { .. })
-                    ) {
+                    // transport 失敗時 in-flight 動作永遠收不到 response，換成錯誤
+                    // banner 避免 spinner 卡死（PR #28 修了 channel send 失敗，這裡修 ws_tx 失敗）
+                    if self
+                        .pending_action
+                        .as_ref()
+                        .is_some_and(PendingAction::is_in_flight)
+                    {
                         self.pending_action = Some(PendingAction::ServerError {
-                            message: "與伺服器斷線，操作已取消".into(),
+                            message: "與伺服器中斷連線，操作已取消".into(),
                         });
                     }
                     tracing::warn!(verbosity = "concise", "與伺服器的連線中斷");
                 }
                 NetEvent::Reconnecting { attempt } => {
                     self.connection_state = ConnectionState::Reconnecting { attempt };
-                    // 重連期間使用者若再次按鈕，同樣標記失敗
-                    if matches!(
-                        self.pending_action,
-                        Some(PendingAction::Joining { .. } | PendingAction::CreatingRoom { .. })
-                    ) {
+                    if self
+                        .pending_action
+                        .as_ref()
+                        .is_some_and(PendingAction::is_in_flight)
+                    {
                         self.pending_action = Some(PendingAction::ServerError {
-                            message: "尚未連線，操作已取消".into(),
+                            message: "與伺服器中斷連線，操作已取消".into(),
                         });
                     }
                     tracing::info!(verbosity = "concise", "正在重新連線... (第 {attempt} 次)");
@@ -594,8 +610,21 @@ impl War3App {
             }
             ServerMessage::Error { message } => {
                 tracing::error!(verbosity = "concise", "伺服器錯誤: {message}");
-                // 把 server 拒絕原因 surface 到紅色 banner，避免使用者按鈕後永遠不知道為何沒反應
-                self.pending_action = Some(PendingAction::ServerError { message });
+                // 依當前 pending 決定如何 surface：
+                // - Joining 中 → JoinFailed 保持語意（reuse「加入失敗」banner）
+                // - CreatingRoom / None → 通用 ServerError banner
+                // - JoinSuccess / 已存在的失敗訊息 → 只 log 不覆蓋（避免吃掉成功狀態或無聲蓋掉前一則錯誤）
+                match self.pending_action.take() {
+                    Some(PendingAction::Joining { .. }) => {
+                        self.pending_action = Some(PendingAction::JoinFailed { reason: message });
+                    }
+                    Some(PendingAction::CreatingRoom { .. }) | None => {
+                        self.pending_action = Some(PendingAction::ServerError { message });
+                    }
+                    Some(existing) => {
+                        self.pending_action = Some(existing);
+                    }
+                }
             }
             ServerMessage::Unknown => {}
         }

--- a/crates/client/src/app.rs
+++ b/crates/client/src/app.rs
@@ -46,6 +46,9 @@ enum PendingAction {
     JoinFailed { reason: String },
     /// User clicked "create room"; waiting for RoomUpdate to confirm.
     CreatingRoom { room_name: String },
+    /// Generic server-side error or transport drop. Surface in red banner.
+    /// Used for: ServerMessage::Error (Register/CreateRoom 拒絕), 連線中斷時取消進行中操作。
+    ServerError { message: String },
 }
 
 pub struct War3App {
@@ -346,10 +349,32 @@ impl War3App {
                 NetEvent::Disconnected => {
                     self.connection_state = ConnectionState::Disconnected;
                     self.my_player_id = None;
+                    // 重置斷線時的 stale state，避免「線上 N 人 + 舊房間列表」幻覺
+                    self.players.clear();
+                    self.rooms.clear();
+                    // 進行中的動作 (Joining/CreatingRoom) 在 transport 失敗時永遠收不到
+                    // server response，把 banner 換成失敗訊息避免 spinner 卡死
+                    if matches!(
+                        self.pending_action,
+                        Some(PendingAction::Joining { .. } | PendingAction::CreatingRoom { .. })
+                    ) {
+                        self.pending_action = Some(PendingAction::ServerError {
+                            message: "與伺服器斷線，操作已取消".into(),
+                        });
+                    }
                     tracing::warn!(verbosity = "concise", "與伺服器的連線中斷");
                 }
                 NetEvent::Reconnecting { attempt } => {
                     self.connection_state = ConnectionState::Reconnecting { attempt };
+                    // 重連期間使用者若再次按鈕，同樣標記失敗
+                    if matches!(
+                        self.pending_action,
+                        Some(PendingAction::Joining { .. } | PendingAction::CreatingRoom { .. })
+                    ) {
+                        self.pending_action = Some(PendingAction::ServerError {
+                            message: "尚未連線，操作已取消".into(),
+                        });
+                    }
                     tracing::info!(verbosity = "concise", "正在重新連線... (第 {attempt} 次)");
                 }
                 NetEvent::ServerMessage(msg) => self.handle_server_message(msg),
@@ -569,6 +594,8 @@ impl War3App {
             }
             ServerMessage::Error { message } => {
                 tracing::error!(verbosity = "concise", "伺服器錯誤: {message}");
+                // 把 server 拒絕原因 surface 到紅色 banner，避免使用者按鈕後永遠不知道為何沒反應
+                self.pending_action = Some(PendingAction::ServerError { message });
             }
             ServerMessage::Unknown => {}
         }
@@ -673,6 +700,25 @@ impl War3App {
                     ui.spinner();
                     ui.label(format!("正在建立房間「{}」...", room_name));
                 });
+                ui.add_space(4.0);
+                true
+            }
+            PendingAction::ServerError { message } => {
+                egui::Frame::new()
+                    .fill(egui::Color32::from_rgba_unmultiplied(35, 15, 15, 200))
+                    .inner_margin(8.0)
+                    .corner_radius(4.0)
+                    .show(ui, |ui| {
+                        ui.horizontal(|ui| {
+                            ui.colored_label(
+                                egui::Color32::from_rgb(0xef, 0x44, 0x44),
+                                format!("錯誤：{}", message),
+                            );
+                            if ui.button("確定").clicked() {
+                                self.pending_action = None;
+                            }
+                        });
+                    });
                 ui.add_space(4.0);
                 true
             }


### PR DESCRIPTION
## Summary

修兩個 silent failure 路徑（接續 PR #28 的 cmd_tx silent drop 修復）：

- **#40** `NetEvent::Disconnected` / `Reconnecting` 不清 `pending_action` / `players` / `rooms` — spinner 卡死 + 「線上 N 人 + 舊房間列表」幻覺
- **#41** `ServerMessage::Error` 只 `tracing::error!` 不顯示 UI — 使用者看不到 server 為何拒絕

## 變動

- 新增 `PendingAction::ServerError { message: String }` variant
- `NetEvent::Disconnected`: 清 `players` / `rooms`，把進行中的 `Joining` / `CreatingRoom` 換成 `ServerError("與伺服器斷線，操作已取消")`
- `NetEvent::Reconnecting`: 同上（in-flight 操作換成 `ServerError("尚未連線，操作已取消")`）
- `ServerMessage::Error`: 設 `pending_action = Some(ServerError { message })`，使用者會看到紅色 banner + 確定按鈕
- 新增 banner UI for `ServerError`（reuse `JoinFailed` 的紅色 frame pattern）

## Test plan

本地驗證：
- [x] `cargo check --workspace --exclude spike-packet`
- [x] `cargo clippy --workspace --exclude spike-packet -- -D warnings`
- [x] `cargo test --workspace --exclude spike-packet` — server 20 test 全 pass
- [x] `cargo fmt --all -- --check`

人類 ET 驗證（手動，待 merge 後跑）：
- [ ] 開兩 client，A 在 War3 建房，B 按「加入」當下拔 B 的網路 → 預期 banner 換成「與伺服器斷線，操作已取消」（紅色 + 確定鈕），而非 spinner 卡死
- [ ] Wizard 暱稱輸入 33 個 CJK 字元 → 預期紅 banner 顯示「錯誤：暱稱超過長度限制」
- [ ] 拔網路後檢查 lobby — 房間列表/玩家列表應消失（不再顯示 stale 資料）
- [ ] 已有房間時按「建立房間」→ server 回 Error → 預期紅 banner 顯示

## 限制 / 已知缺口（留作 follow-up）

- `cmd_tx` 是 unbounded channel；連線斷掉時排隊的 commands（如已送出的 `JoinRoom`）會在 reconnect 後**延遲送出**到 server，可能造成「使用者已被告知取消但 server 還是 process 該 command」的情境。本 PR 不處理此 race，需另開 issue
- 沒有 unit test：War3App 結構複雜（含 mpsc/tokio handle），單測需要大量 mock。修法簡單（~30 行邏輯）依賴人類 ET + multi-agent review，後續若要加可考慮抽 `clear_session_state(&mut self, full: bool)` helper

## 相關

- Closes #40, Closes #41
- Follows PR #28 (cmd_tx silent drop fix)
- ET charter `quality/et-sessions/2026-05-16-{network-disruption,rapid-input}.md` 的 HIGH 信心 pre-flight 發現

🤖 Generated with [Claude Code](https://claude.com/claude-code)