### PR TITLE
fix: JoinResult state guard 防 queued cmd reconnect 鬼影 (#44 Option C)

### DIFF
--- a/crates/client/src/app.rs
+++ b/crates/client/src/app.rs
@@ -535,6 +535,17 @@ impl War3App {
                 tunnel_token,
                 gameinfo,
             } => {
+                // queued JoinRoom 可能在 reconnect 後才送達 server，此時 client 端 pending 已不是
+                // Joining（已被 Disconnected handler 換成 ServerError，或使用者按確定後變 None）
+                // 略過自動 tunnel 啟動，避免「ServerError banner + 自動進遊戲」鬼影 (#44)
+                if !matches!(self.pending_action, Some(PendingAction::Joining { .. })) {
+                    tracing::warn!(
+                        verbosity = "concise",
+                        "略過過期的 JoinResult (success={success}) — 操作已取消或已超時"
+                    );
+                    return;
+                }
+
                 if success {
                     self.pending_action = Some(PendingAction::JoinSuccess);
                     if let (Some(token), Some(gi)) = (tunnel_token, gameinfo) {


### PR DESCRIPTION
## Summary

修 #44 描述的 reconnect race（PR #43 review 撈出）— queued `JoinRoom` 在 transport 斷掉後仍躺在 mpsc channel，reconnect 成功後送達 server，造成「先紅 banner 已取消、然後自動進遊戲」矛盾。

採用 issue body 中的 **Option C minimal** — JoinResult handler 加 state guard，pending 非 `Joining` 時 log warn 並 return（不啟動 tunnel、不設 JoinSuccess）。

## 變動

`crates/client/src/app.rs` JoinResult handler 開頭加：

```rust
if !matches!(self.pending_action, Some(PendingAction::Joining { .. })) {
    tracing::warn!(verbosity = "concise", "略過過期的 JoinResult (success={success}) ...");
    return;
}
```

## 已知限制（Option C 範圍）

- **host 側的 CreateRoom race 沒完全 fix**：queued `CreateRoom` reconnect 後仍送達 → server 建房 → `RoomUpdate` broadcast。`pending` 已是 `ServerError`（非 `CreatingRoom`），所以**不會自動帶入 hosting flow**，但**鬼影房間會出現在列表中**。使用者可手動「關閉房間」清掉，至少是 transparent
- **協議層 race 沒解**：完整 fix 是 Option A（client-side request_id 給每個 user action，server response 帶回，client 校驗）。Scope 大、需 protocol 改動，留下次

## Test plan

- [x] `cargo check --workspace --exclude spike-packet`
- [x] `cargo clippy --workspace --exclude spike-packet -- -D warnings`
- [x] `cargo test --workspace --exclude spike-packet` — 20 server tests + 6 protocol tests 全 pass
- [x] `cargo fmt --all -- --check`
- [ ] 人類 ET：拔網 mid-join 後手動 5 秒內重連，預期 log 出現「略過過期的 JoinResult」且**不會**自動進遊戲

## 相關

- Closes #44
- Follows PR #43 (#40 + #41)

🤖 Generated with [Claude Code](https://claude.com/claude-code)