### PR TITLE
refactor(client): CmdSender newtype 強制 send_or_warn (#32)

### DIFF
--- a/crates/client/src/app.rs
+++ b/crates/client/src/app.rs
@@ -7,6 +7,7 @@ use eframe::egui;
 use tokio::sync::{mpsc, oneshot};
 use war3_protocol::messages::{ClientMessage, PlayerInfo, RoomInfo, ServerMessage};
 
+use crate::cmd_sender::CmdSender;
 use crate::logging::LogEntry;
 use crate::net::discovery::NetEvent;
 use crate::net::packet::{RawUdpInjector, check_room};
@@ -66,7 +67,7 @@ pub struct War3App {
     config: crate::config::AppConfig,
     config_changed: bool,
 
-    cmd_tx: mpsc::UnboundedSender<ClientMessage>,
+    cmd_tx: CmdSender,
     event_rx: mpsc::UnboundedReceiver<NetEvent>,
 
     /// Tokio runtime handle for spawning tunnel tasks
@@ -129,7 +130,7 @@ impl War3App {
     pub fn new(
         cc: &eframe::CreationContext<'_>,
         config: crate::config::AppConfig,
-        cmd_tx: mpsc::UnboundedSender<ClientMessage>,
+        cmd_tx: CmdSender,
         event_rx: mpsc::UnboundedReceiver<NetEvent>,
         rt_handle: tokio::runtime::Handle,
         server_url: String,
@@ -225,9 +226,8 @@ impl War3App {
 
     fn send_register(&self) {
         // 失敗即代表網路任務已死、整個 client 處於不可恢復狀態，
-        // 沒有額外 UI 狀態可重置，warn 已由 helper 記錄
-        let _ = try_send_cmd(
-            &self.cmd_tx,
+        // 沒有額外 UI 狀態可重置，warn 已由 send_or_warn 記錄
+        let _ = self.cmd_tx.send_or_warn(
             ClientMessage::Register {
                 nickname: self.config.nickname.clone(),
                 war3_version: self.config.war3_version,
@@ -399,8 +399,7 @@ impl War3App {
 
         // 處理 host UPnP mapped 通知（背景 task → app → server）
         while let Ok((token, addr)) = self.upnp_mapped_rx.try_recv() {
-            let sent = try_send_cmd(
-                &self.cmd_tx,
+            let sent = self.cmd_tx.send_or_warn(
                 ClientMessage::UPnPMapped {
                     external_addr: addr.to_string(),
                     tunnel_token: token,
@@ -486,8 +485,7 @@ impl War3App {
                             verbosity = "concise",
                             "請先在 War3 中建立遊戲，再回來建立房間"
                         );
-                    } else if !try_send_cmd(
-                        &self.cmd_tx,
+                    } else if !self.cmd_tx.send_or_warn(
                         ClientMessage::CreateRoom {
                             room_name,
                             map_name,
@@ -975,29 +973,6 @@ impl Drop for War3App {
     }
 }
 
-/// 嘗試送出命令到背景 network task。失敗代表 receiver 已 drop
-/// （網路任務退出、tokio runtime 關閉、或 app 正在 shutdown），
-/// 記錄 warn 並回傳 false 讓呼叫端可以重置 UI pending 狀態，
-/// 避免使用者按按鈕無反應、無錯誤。
-///
-/// 回傳 bool 必須處理：若忽略則退化為 silent drop（#23 修復前的行為）。
-#[must_use = "send 失敗時呼叫端需要清除 pending UI 狀態，否則使用者會卡在 loading"]
-pub(crate) fn try_send_cmd(
-    cmd_tx: &mpsc::UnboundedSender<ClientMessage>,
-    msg: ClientMessage,
-    action_label: &str,
-) -> bool {
-    if let Err(e) = cmd_tx.send(msg) {
-        tracing::warn!(
-            verbosity = "concise",
-            "{action_label} 未送出：背景任務已中斷（{e}）"
-        );
-        false
-    } else {
-        true
-    }
-}
-
 /// SSRF 防護：拒絕 RFC1918、loopback、link-local 位址
 fn is_safe_external_addr(ip: std::net::IpAddr) -> bool {
     match ip {
@@ -1193,23 +1168,5 @@ mod tests {
     fn valid_external_addr_public_is_accepted() {
         let addr: SocketAddr = "203.0.113.50:19870".parse().unwrap();
         assert!(is_safe_external_addr(addr.ip()));
-    }
-
-    // ── try_send_cmd: 確保使用者命令失敗不再被靜默丟棄 (#23) ──
-
-    #[test]
-    fn try_send_cmd_returns_true_when_receiver_alive() {
-        let (tx, mut rx) = mpsc::unbounded_channel::<ClientMessage>();
-        let ok = try_send_cmd(&tx, ClientMessage::CloseRoom, "關閉房間");
-        assert!(ok);
-        assert!(matches!(rx.try_recv(), Ok(ClientMessage::CloseRoom)));
-    }
-
-    #[test]
-    fn try_send_cmd_returns_false_when_receiver_dropped() {
-        let (tx, rx) = mpsc::unbounded_channel::<ClientMessage>();
-        drop(rx);
-        let ok = try_send_cmd(&tx, ClientMessage::CloseRoom, "關閉房間");
-        assert!(!ok);
     }
 }

--- a/crates/client/src/cmd_sender.rs
+++ b/crates/client/src/cmd_sender.rs
@@ -1,0 +1,61 @@
+use tokio::sync::mpsc;
+use war3_protocol::messages::ClientMessage;
+
+/// Newtype wrapper for the cmd channel sender 強制使用 `send_or_warn`，
+/// 避免新增 call site 時直接 `.send()` 繞過 logging。
+///
+/// 演進：PR #28 加了 `try_send_cmd` free function + `#[must_use]`（解 #23
+/// silent-drop bug），但 `mpsc::UnboundedSender<ClientMessage>` 仍可被
+/// bypass。本 newtype 收緊 type system 把它變成不可能（#32）。
+#[derive(Clone)]
+pub struct CmdSender(mpsc::UnboundedSender<ClientMessage>);
+
+impl CmdSender {
+    pub(crate) fn new(tx: mpsc::UnboundedSender<ClientMessage>) -> Self {
+        Self(tx)
+    }
+
+    /// 送 cmd 到 background network task。失敗時 warn log，回傳 true = 成功。
+    ///
+    /// `action_label` 是**使用者可見的繁體中文動詞片語**（e.g. "建立房間"、
+    /// "加入"、"關閉房間"），會出現在 UI log panel 為
+    /// `"{action_label} 未送出：背景任務已中斷（...）"`。不要傳英文 dev string——
+    /// 使用者直接看到。
+    ///
+    /// 回傳 bool 必須處理：若忽略則退化為 silent drop（#23 修復前的行為）。
+    #[must_use = "send_or_warn 失敗時呼叫端需要清除 pending UI 狀態，否則使用者會卡在 loading"]
+    pub fn send_or_warn(&self, msg: ClientMessage, action_label: &str) -> bool {
+        if let Err(e) = self.0.send(msg) {
+            tracing::warn!(
+                verbosity = "concise",
+                "{action_label} 未送出：背景任務已中斷（{e}）"
+            );
+            false
+        } else {
+            true
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn send_or_warn_returns_true_when_receiver_alive() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let sender = CmdSender::new(tx);
+        let ok = sender.send_or_warn(ClientMessage::CloseRoom, "關閉房間");
+        assert!(ok);
+        assert!(matches!(rx.try_recv(), Ok(ClientMessage::CloseRoom)));
+    }
+
+    #[test]
+    fn send_or_warn_returns_false_when_receiver_dropped() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let sender = CmdSender::new(tx);
+        drop(rx);
+        let ok = sender.send_or_warn(ClientMessage::CloseRoom, "關閉房間");
+        assert!(!ok);
+    }
+}

--- a/crates/client/src/main.rs
+++ b/crates/client/src/main.rs
@@ -1,4 +1,5 @@
 mod app;
+mod cmd_sender;
 mod config;
 mod logging;
 mod net;
@@ -12,6 +13,7 @@ use tracing_subscriber::Layer;
 use tracing_subscriber::layer::SubscriberExt;
 
 use app::War3App;
+use cmd_sender::CmdSender;
 use config::AppConfig;
 use logging::UiLogLayer;
 use net::discovery::{self, NetEvent};
@@ -55,8 +57,10 @@ fn main() {
     let config = AppConfig::load();
     let server_url = config.server_url.clone();
 
-    // 建立 UI ↔ Network 通道
-    let (cmd_tx, cmd_rx) = mpsc::unbounded_channel::<ClientMessage>();
+    // 建立 UI ↔ Network 通道。CmdSender wraps the sender — UI 端只能透過
+    // send_or_warn 出 cmd，型別系統保證 logging path 不被 bypass（#32）。
+    let (raw_cmd_tx, cmd_rx) = mpsc::unbounded_channel::<ClientMessage>();
+    let cmd_tx = CmdSender::new(raw_cmd_tx);
     let (event_tx, event_rx) = mpsc::unbounded_channel::<NetEvent>();
 
     let latency_ms = Arc::new(AtomicU64::new(0));

--- a/crates/client/src/ui/lobby.rs
+++ b/crates/client/src/ui/lobby.rs
@@ -1,6 +1,7 @@
 use eframe::egui;
 use war3_protocol::messages::{ClientMessage, PlayerInfo, RoomInfo};
 
+use crate::cmd_sender::CmdSender;
 use crate::net::quic::{StrategyOutcome, StrategyResult};
 use crate::net::tunnel::Transport;
 
@@ -35,7 +36,7 @@ impl LobbyPanel {
         players: &[PlayerInfo],
         my_nickname: Option<&str>,
         is_hosting: bool,
-        cmd_tx: &tokio::sync::mpsc::UnboundedSender<ClientMessage>,
+        cmd_tx: &CmdSender,
         latency_ms: u64,
         transport: Option<Transport>,
         diagnostics: &[StrategyResult],
@@ -143,8 +144,7 @@ impl LobbyPanel {
                                             } else if room_full {
                                                 ui.add_enabled(false, egui::Button::new("已滿"));
                                             } else if ui.button("加入").clicked() {
-                                                let sent = crate::app::try_send_cmd(
-                                                    cmd_tx,
+                                                let sent = cmd_tx.send_or_warn(
                                                     ClientMessage::JoinRoom {
                                                         room_id: room.room_id.clone(),
                                                     },
@@ -195,8 +195,8 @@ impl LobbyPanel {
         // 建房 / 關房按鈕
         if is_hosting {
             if ui.button("關閉房間").clicked() {
-                // 失敗的話 server 端房間還在但 client 已斷線，warn 已由 helper 記錄
-                let _ = crate::app::try_send_cmd(cmd_tx, ClientMessage::CloseRoom, "關閉房間");
+                // 失敗的話 server 端房間還在但 client 已斷線，warn 已由 send_or_warn 記錄
+                let _ = cmd_tx.send_or_warn(ClientMessage::CloseRoom, "關閉房間");
             }
         } else {
             let create_btn = egui::Button::new("+ 建立房間")


### PR DESCRIPTION
## Summary

`mpsc::UnboundedSender<ClientMessage>` 包成 `CmdSender` newtype。型別系統強制所有 cmd send 走 `send_or_warn` (含 warn log + `#[must_use]`)，徹底消除新 call site 直接 `.send()` 繞過 logging 的 regression 風險。

延續 PR #28（`try_send_cmd` free function + `#[must_use]` 解 #23 silent-drop）的第三層防線。

## Migration

| 舊 | 新 |
|---|---|
| `try_send_cmd(&self.cmd_tx, msg, label)` | `self.cmd_tx.send_or_warn(msg, label)` |
| `crate::app::try_send_cmd(cmd_tx, msg, label)` | `cmd_tx.send_or_warn(msg, label)` |

Message format 完全相同：`"{label} 未送出：背景任務已中斷（{e}）"`。UiLogLayer render UX 不變。

## Changed

- 新 `crates/client/src/cmd_sender.rs`（~60 LOC + 2 tests）
- `War3App.cmd_tx` field + ctor param 型別 `CmdSender`
- `LobbyPanel::show` `cmd_tx` 參數型別 `&CmdSender`
- 5 個 send call sites（app.rs × 3 + lobby.rs × 2）migrate 完成
- 移除 `app.rs:985-999` `try_send_cmd` free function + tests

## Test plan

- [x] `cargo check --workspace --exclude spike-packet`
- [x] `cargo test --workspace --exclude spike-packet` — 142 tests 全綠
- [x] `cargo clippy --workspace --exclude spike-packet -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `grep -rn try_send_cmd crates/ docs/` 只剩 cmd_sender.rs 內歷史 reference doc
- [x] `#[must_use]` 在所有 5 個 call sites 有效（保留 `let _` / `let sent` / `if !` patterns）

## CHANGELOG

CHANGELOG bump 跟 Phase 4 v0.4.1 release PR 同步。

設計來源：`tim-master-design-20260516-231321.md` Step 3 (UC-3 newtype 簡化版 + Step 5c doc D9 refinement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)