### PR TITLE
docs(quality): xref backlog-audit.md from 4 quality docs (v0.4.1 follow-up)

### DIFF
--- a/quality/README.md
+++ b/quality/README.md
@@ -141,4 +141,5 @@ war3-battle-tool 的品質管理體系。追蹤缺陷、技術債、功能缺口
 - [discovery-strategy.md](./discovery-strategy.md) — 雙層品質發現模型
 - [et-charter-template.md](./et-charter-template.md) — 探索式測試 Charter 模板
 - [defect-taxonomy.md](./defect-taxonomy.md) — 缺陷分類學搜查手冊
+- [backlog-audit.md](./backlog-audit.md) — Deferred issues staleness 審查協議
 - [quality-system-design-notes.md](./quality-system-design-notes.md) — 設計筆記與方法論來源

--- a/quality/defect-taxonomy.md
+++ b/quality/defect-taxonomy.md
@@ -476,6 +476,7 @@ Trigger: 重要 PR 修改安全相關 code 後
 
 - [discovery-strategy.md](./discovery-strategy.md) — 雙層模型：搜查手冊與 ET 如何互饋
 - [et-charter-template.md](./et-charter-template.md) — Charter 模板與 Quick Start
+- [backlog-audit.md](./backlog-audit.md) — Deferred items 處理協議（搜查找出來後的下一站）
 - [README.md](./README.md) — 品質管理追蹤總覽
 
 ---

--- a/quality/discovery-strategy.md
+++ b/quality/discovery-strategy.md
@@ -144,6 +144,7 @@ Charter 模板和使用說明見 [et-charter-template.md](./et-charter-template.
 
 - [et-charter-template.md](./et-charter-template.md) — Charter 模板與 Quick Start
 - [defect-taxonomy.md](./defect-taxonomy.md) — 搜查手冊（含各類別的 charter seed）
+- [backlog-audit.md](./backlog-audit.md) — Deferred items 處理協議（發現後不立即修的 staleness review）
 - [README.md](./README.md) — 品質管理追蹤總覽
 - [quality-system-design-notes.md](./quality-system-design-notes.md) — 設計筆記與方法論來源
 - [examples/sparkle/et-charters.md](../examples/sparkle/et-charters.md) — 真實 ET 執行範例

--- a/quality/et-charter-template.md
+++ b/quality/et-charter-template.md
@@ -134,5 +134,6 @@ Session report 中記錄你探索了什麼、為什麼沒發現問題，這些�
 
 - [discovery-strategy.md](./discovery-strategy.md) — 雙層模型與互饋迴圈
 - [defect-taxonomy.md](./defect-taxonomy.md) — 搜查手冊（含各類別的 charter seed）
+- [backlog-audit.md](./backlog-audit.md) — Deferred items 處理協議
 - [README.md](./README.md) — 品質管理追蹤總覽
 - [examples/sparkle/et-charters.md](../examples/sparkle/et-charters.md) — 真實 ET 執行範例


### PR DESCRIPTION
## Summary

v0.4.1 PR #47 introduced `quality/backlog-audit.md` (deferred-issues staleness protocol) but the 4 existing quality docs' "See also" sections didn't pick up the cross-reference. This PR closes that drift.

## Files

| File | Change |
|---|---|
| `quality/README.md` | Add `backlog-audit.md` line to See also |
| `quality/defect-taxonomy.md` | Add `backlog-audit.md` line — phrasing makes it「找出來後的下一站」 |
| `quality/discovery-strategy.md` | Add `backlog-audit.md` line — phrasing makes it「發現後不立即修的 staleness review」 |
| `quality/et-charter-template.md` | Add `backlog-audit.md` line |

Each addition is 1 line. Zero content rewrite. Future readers of any quality doc can now reach the audit protocol within one hop.

## Source

`/document-release` post-ship audit sweep (2026-05-18). v0.4.1 docs (README、CLAUDE.md、CHANGELOG、TODOS、WINDOWS_INTEGRATION) are in current state. Only finding: 4 missing cross-references above.

## Test plan

- [ ] CI passes (docs-only)
- [ ] Each See also block has `backlog-audit.md` at expected position
- [ ] Backlog audit protocol reachable from quality/README.md in 1 click

🤖 Generated with [Claude Code](https://claude.com/claude-code)